### PR TITLE
CassandraLogger prefix made configurable

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/cassandra/CassandraLogger.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/cassandra/CassandraLogger.java
@@ -12,7 +12,7 @@ import com.readytalk.metrics.StatsDReporter;
  * Cassandra's Java client has its own monitoring using codahale metrics. This class can route those 
  * metrics into statsd, so that they go together with the other metrics what Kamon is collecting.
  * 
- * This relies on akka-persistence-cassandra's ability to expose the cassandra meterics 
+ * This relies on akka-persistence-cassandra's ability to expose the cassandra metrics
  * using {@link akka.persistence.cassandra.CassandraMetricsRegistry}.
  */
 public class CassandraLogger {
@@ -25,9 +25,9 @@ public class CassandraLogger {
         String statsdhost = system.settings().config().getString("codahale.statsd.hostname");
         int statsdport = system.settings().config().getInt("codahale.statsd.port");
         long interval = system.settings().config().getDuration("codahale.statsd.tick-interval", TimeUnit.MILLISECONDS);
-        
+        String prefix = system.settings().config().getString("codahale.statsd.prefix");
         StatsDReporter.forRegistry(registry)
-            .prefixedWith("documentcore")
+            .prefixedWith(prefix)
             .build(statsdhost, statsdport)           
             .start(interval, TimeUnit.MILLISECONDS);
     }

--- a/ts-reaktive-actors/src/main/resources/reference.conf
+++ b/ts-reaktive-actors/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+codahale.statsd {
+  hostname = "localhost"
+  port = 8125
+  tick-interval = 5000
+  prefix = "cassandra-client"
+}


### PR DESCRIPTION
Prefix is optional and configurable by system settings. By default value is `reaktive`
@jypma @alar17 