### PR TITLE
fixed generic type for CompletableFutures.sequence

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/CompletableFutures.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/CompletableFutures.java
@@ -24,14 +24,14 @@ public class CompletableFutures {
     /**
      * Returns a future that completes when all the futures in the given collection have completed.
      */
-    public static <T> CompletableFuture<List<T>> sequence(Collection<CompletableFuture<? extends T>> futures) {
+    public static <T,U extends T> CompletableFuture<List<T>> sequence(Collection<CompletableFuture<U>> futures) {
         return sequence(futures.stream());
     }
     
     /**
      * Returns a future that completes when all the futures in the given stream have completed.
      */
-    public static <T> CompletableFuture<List<T>> sequence(Stream<CompletableFuture<? extends T>> futures) {
+    public static <T,U extends T> CompletableFuture<List<T>> sequence(Stream<CompletableFuture<U>> futures) {
         return CompletableFuture.supplyAsync(() -> futures.map(f -> f.join()).collect(Collectors.toList()));
     }
     

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/CompletableFutureSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/CompletableFutureSpec.java
@@ -1,0 +1,35 @@
+package com.tradeshift.reaktive;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+
+@RunWith(CuppaRunner.class)
+public class CompletableFutureSpec {
+    {
+        describe("CompletableFuture sequence method", () -> {
+            it("should return a future that completes when all the futures in the given stream have completed.", () -> {
+                Collection<CompletableFuture<Integer>> futures = new ArrayList<>();
+                CompletableFuture<Integer> future1 = new CompletableFuture<>();
+                CompletableFuture<Integer> future2 = new CompletableFuture<>();
+                futures.add(future1);
+                futures.add(future2);
+                CompletableFuture<List<Number>> sequence = CompletableFutures.sequence(futures);
+                future1.complete(1);
+                future2.complete(2);
+                List<Number> result = sequence.get();
+                assertThat(result).hasSize(2);
+                assertThat(result.get(0)).isEqualTo(1);
+                assertThat(result.get(1)).isEqualTo(2);
+            });
+        });
+    }
+}


### PR DESCRIPTION
Fixed generic type and added a simple unit test for CompletableFutures#sequence.

Without the type change the test results in compilation error

```
method com.tradeshift.reaktive.CompletableFutures.<T>sequence(java.util.Collection<java.util.concurrent.CompletableFuture<? extends T>>) is not applicable
      (cannot infer type-variable(s) T
        (argument mismatch; java.util.ArrayList<java.util.concurrent.CompletableFuture<java.lang.Integer>> cannot be converted to java.util.Collection<java.util.concurrent.CompletableFuture<? extends T>>))
```

@jypma 

