### PR TITLE
Two unrelated additions

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/cassandra/CassandraSession.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/cassandra/CassandraSession.java
@@ -1,0 +1,49 @@
+package com.tradeshift.reaktive.cassandra;
+
+import static com.tradeshift.reaktive.Lambdas.toScala;
+import static scala.compat.java8.FutureConverters.toJava;
+import static scala.compat.java8.FutureConverters.toScala;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+
+import akka.actor.ActorSystem;
+import akka.persistence.cassandra.CassandraPluginConfig;
+
+/**
+ * Provides asynchronous, non-blocking access to a cassandra session.
+ */
+public class CassandraSession {
+    private final akka.persistence.cassandra.CassandraSession delegate;
+    
+    public CassandraSession(ActorSystem system, String metricsCategory, Function<Session,CompletionStage<Void>> init) {
+        CassandraPluginConfig config = new CassandraPluginConfig(system, system.settings().config().getConfig("cassandra-journal"));
+        this.delegate = new akka.persistence.cassandra.CassandraSession(system, config, system.dispatcher(), system.log(), metricsCategory, 
+            toScala(init.andThen(f -> toScala(f))));
+    }
+    
+    public CompletionStage<Session> getUnderlying() {
+        return toJava(delegate.underlying());
+    }
+    
+    public CompletionStage<PreparedStatement> prepare(String stmt) {
+        return toJava(delegate.prepare(stmt));
+    }
+    
+    public CompletionStage<Void> executeWrite(Statement stmt) {
+        return toJava(delegate.executeWrite(stmt)).thenApply(unit -> null);
+    }
+
+    public CompletionStage<ResultSet> select(Statement stmt) {
+        return toJava(delegate.select(stmt));
+    }
+    
+    public void close() {
+        delegate.close();
+    }
+}

--- a/ts-reaktive-testkit/build.sbt
+++ b/ts-reaktive-testkit/build.sbt
@@ -12,3 +12,13 @@ EclipseKeys.projectFlavor := EclipseProjectFlavor.Java
 
 // Because of https://github.com/cuppa-framework/cuppa/pull/113
 parallelExecution in Test := false
+
+libraryDependencies ++= {
+  Seq(
+    "junit" % "junit" % "4.11" % "test",
+    "org.assertj" % "assertj-core" % "3.2.0" % "test",
+    "com.novocode" % "junit-interface" % "0.11" % "test",
+    "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
+    "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test"
+  )
+}

--- a/ts-reaktive-testkit/src/main/java/com/tradeshift/reaktive/testkit/Await.java
+++ b/ts-reaktive-testkit/src/main/java/com/tradeshift/reaktive/testkit/Await.java
@@ -1,0 +1,104 @@
+package com.tradeshift.reaktive.testkit;
+
+import java.util.concurrent.TimeUnit;
+
+import akka.japi.pf.FI;
+import javaslang.CheckedFunction0;
+
+/**
+ * Contains utility methods that repeatedly try to evaluate a function, retrying when an 
+ * assertion does not (yet) hold.
+ */
+public class Await {
+    private static final long defaultStartInterval = 30;
+    private static final long defaultMaxInterval = 500;
+    private static final long defaultTimeoutSeconds = 10;
+    
+    /**
+     * Holds a timeout configuration, on which assertion blocks can be repeatedly attempted.
+     */
+    public static class Within {
+        private final long amount;
+        private final TimeUnit unit;
+        
+        private Within(long amount, TimeUnit unit) {
+            this.amount = amount;
+            this.unit = unit;
+        }
+        
+        /**
+         * Repeatedly tries to evaluate the given function, re-trying whenever it fails with
+         * an AssertionError. Any other exception will be thrown immediately.
+         * @return The final return value of [f], if invoked successfully
+         */
+        public <T> T eventually(CheckedFunction0<T> f) {
+            final long deadline = System.currentTimeMillis() + unit.toMillis(amount);
+            long delay = defaultStartInterval;
+            AssertionError lastError;
+            do {
+                try {
+                    return f.apply();
+                } catch (AssertionError x) {
+                    lastError = x;
+                    // re-try
+                    try { 
+                        Thread.sleep(delay); 
+                    } catch (InterruptedException y) {
+                        throw new RuntimeException(x);
+                    }
+                    delay = Math.min((long) (delay * 1.2), defaultMaxInterval);
+                } catch (RuntimeException x) {
+                    throw x;
+                } catch (Throwable x) {
+                    throw new RuntimeException(x);
+                }
+            } while (System.currentTimeMillis() < deadline);
+            
+            throw new AssertionError("Timed out after " + amount + " " + unit + ". Last error: ", lastError);
+        }
+        
+        /**
+         * Repeatedly tries to evaluate the given function, re-trying whenever it fails with
+         * an AssertionError. Any other exception will be thrown immediately.
+         */
+        public void eventuallyDo(FI.UnitApplyVoid f) {
+            eventually(() -> { 
+                f.apply(); 
+                return null; 
+            });
+        }
+    }
+    
+    /**
+     * Prepares to repeatedly attempt a block of assertions. This is part of a DSL; invoke [eventually]
+     * on the returned object to actually call a block. For example:
+     * 
+     *     within(1, SECONDS).eventuallyDo(() -> {
+     *         assertThat(myMessage.hasArrived()).isTrue(); 
+     *     });
+     */
+    public static Within within(long amount, TimeUnit unit) {
+        return new Within(amount, unit);
+    }
+    
+    /**
+     * Repeatedly tries to evaluate the given function, re-trying whenever it fails with
+     * an AssertionError. Any other exception will be thrown immediately. 
+     * 
+     * A default timeout of 10 seconds is applied.
+     * @return The final return value of [f], if invoked successfully
+     */
+    public static <T> T eventually(CheckedFunction0<T> f) {
+        return within(defaultTimeoutSeconds, TimeUnit.SECONDS).eventually(f);
+    }
+    
+    /**
+     * Repeatedly tries to evaluate the given function, re-trying whenever it fails with
+     * an AssertionError. Any other exception will be thrown immediately.
+     * 
+     * A default timeout of 10 seconds is applied.
+     */
+    public static void eventuallyDo(FI.UnitApplyVoid f) {
+        within(defaultTimeoutSeconds, TimeUnit.SECONDS).eventuallyDo(f);
+    }    
+}

--- a/ts-reaktive-testkit/src/test/java/com/tradeshift/reaktive/testkit/AwaitSpec.java
+++ b/ts-reaktive-testkit/src/test/java/com/tradeshift/reaktive/testkit/AwaitSpec.java
@@ -1,0 +1,62 @@
+package com.tradeshift.reaktive.testkit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(CuppaRunner.class)
+public class AwaitSpec {{
+    describe("Await.eventuallyDo", () -> {
+        it("should immediately throw any non-assertion exception", () -> {
+            AtomicInteger count = new AtomicInteger();
+            
+            assertThatThrownBy(() -> 
+                Await.eventuallyDo(() -> {
+                    count.incrementAndGet();
+                    throw new RuntimeException("simulated failure");
+                })
+            ).hasMessageContaining("simulated failure");
+            
+            assertThat(count.get()).isEqualTo(1);
+        });
+        
+        it("should retry on assertion errors", () -> {
+            AtomicInteger count = new AtomicInteger();
+            
+            Await.eventuallyDo(() -> {
+                int i = count.incrementAndGet();
+                assertThat(i).isGreaterThan(2);
+            });
+            
+            assertThat(count.get()).isEqualTo(3);            
+        });
+    });
+    
+    describe("Await.eventually", () -> {
+        it("should return the value of the inner lambda if successful", () -> {
+            assertThat(
+                Await.eventually(() -> 5)
+            ).isEqualTo(5);
+        });
+    });
+    
+    describe("Await.within", () -> {
+        it("should abort when the given timeout has passed", () -> {
+            
+            assertThatThrownBy(() -> 
+                Await.within(1, TimeUnit.MILLISECONDS).eventuallyDo(() -> {
+                    Thread.sleep(10);
+                    assertThat(false).isEqualTo(true);
+                }))
+            .hasMessageContaining("Timed out")
+            .isInstanceOf(AssertionError.class);
+        });
+    });
+}}


### PR DESCRIPTION
- Provide a thin Java wrapper around the async CassandraSession
- Add Eventually to do scalatest-like "eventually { ... }" in tests

@ehats @alar17 please review