### PR TITLE
Adding protobuf definition for EventEnvelope so EventRoute can be concrete

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0")
+
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.4.0")

--- a/ts-reaktive-actors/build.sbt
+++ b/ts-reaktive-actors/build.sbt
@@ -30,3 +30,14 @@ libraryDependencies ++= {
     "com.github.tomakehurst" % "wiremock" % "1.58" % "test"
   )
 }
+
+
+dependencyOverrides += "com.google.protobuf" % "protobuf-java" % "2.6.1"
+
+import sbtprotobuf.{ProtobufPlugin=>PB}
+
+// Protobuf initialization
+Seq(PB.protobufSettings: _*)
+
+// include *.proto files in packaged jar
+unmanagedResourceDirectories in Compile <+= (sourceDirectory in PB.protobufConfig)

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/protobuf/UUIDs.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/protobuf/UUIDs.java
@@ -1,0 +1,28 @@
+package com.tradeshift.reaktive.protobuf;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+import javaslang.collection.SortedSet;
+import javaslang.collection.TreeSet;
+
+public class UUIDs {
+    public static final String UUID_EX = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
+
+    public static Types.UUID toProtobuf(UUID javaUUID) {
+        return Types.UUID.newBuilder()
+            .setLeastSignificantBits(javaUUID.getLeastSignificantBits())
+            .setMostSignificantBits(javaUUID.getMostSignificantBits())
+            .build();
+    }
+    
+    public static UUID toJava(Types.UUID protobufUUID) {
+        return new UUID(protobufUUID.getMostSignificantBits(), protobufUUID.getLeastSignificantBits());
+    }
+
+    public static SortedSet<UUID> splitIntoUUIDs(String commaSeparatedUuids) {
+        return Arrays.stream(commaSeparatedUuids.split(","))
+            .map(UUID::fromString)
+            .collect(TreeSet.collector());
+    }
+}

--- a/ts-reaktive-actors/src/main/protobuf/Query.proto
+++ b/ts-reaktive-actors/src/main/protobuf/Query.proto
@@ -1,0 +1,10 @@
+package com.tradeshift.reaktive.protobuf;
+
+import "Types.proto";
+
+message EventEnvelope {
+    optional string persistenceId = 1;      
+    optional uint64 sequenceNr = 2;
+    optional uint64 offset = 3;
+    optional bytes event = 4;
+}

--- a/ts-reaktive-actors/src/main/protobuf/Types.proto
+++ b/ts-reaktive-actors/src/main/protobuf/Types.proto
@@ -1,0 +1,9 @@
+package com.tradeshift.reaktive.protobuf;
+
+/**
+ * A 128-bit id, transferred as two 64-bit longs
+ */
+message UUID {
+    required fixed64 least_significant_bits = 1;
+    required fixed64 most_significant_bits = 2;
+}

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/akka/rest/EventRouteIntegrationSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/akka/rest/EventRouteIntegrationSpec.java
@@ -21,7 +21,7 @@ import com.tradeshift.reaktive.testkit.HttpIntegrationSpec;
 public class EventRouteIntegrationSpec extends HttpIntegrationSpec {
     static class TestEventRoute extends EventRoute {
         public TestEventRoute(EventsByTagQuery journal) {
-            super(materializer, journal, "testEvent");
+            super(system, materializer, journal, "testEvent");
         }
 
         @Override


### PR DESCRIPTION
Needed to have something to transmit between datacenters in https://github.com/Tradeshift/ts-reaktive/pull/8 .