### PR TITLE
StaxWriter should auto-create namespaces for StartElement events

### DIFF
--- a/ts-reaktive-marshal-akka/src/test/java/com/tradeshift/reaktive/marshal/stream/StaxWriterSpec.java
+++ b/ts-reaktive-marshal-akka/src/test/java/com/tradeshift/reaktive/marshal/stream/StaxWriterSpec.java
@@ -6,18 +6,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.XMLEvent;
 
 import org.forgerock.cuppa.junit.CuppaRunner;
 import org.junit.runner.RunWith;
 import org.xmlunit.builder.Input;
 
-import com.tradeshift.reaktive.marshal.stream.StaxWriter;
 import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
 
 import akka.stream.javadsl.Source;
@@ -38,6 +41,40 @@ public class StaxWriterSpec extends SharedActorSystemSpec {{
                 .toCompletableFuture().get(1, TimeUnit.SECONDS);
 
             assertThat(result.toArray(), isIdenticalTo(Input.fromURL(getClass().getResource("/test.xml"))));
+        });
+        
+        it("Should augment startElement events with namespace prefix mappings when they're introduced", () -> {
+            XMLEventFactory factory = XMLEventFactory.newFactory();
+            Attribute attr = factory.createAttribute(new QName("uri:attrns", "a", "atprefix"), "hello");
+            ByteString result = Source.from(Arrays.<XMLEvent>asList(
+                factory.createStartElement(new QName("uri:ns1","tag","prefix"), null, null),
+                factory.createStartElement(new QName("uri:ns2","tag","prefix"), Arrays.asList(attr).iterator(), null),
+                factory.createEndElement(new QName("uri:ns2","tag","prefix"), null),
+                factory.createEndElement(new QName("uri:ns1","tag","prefix"), null)
+            ))
+            .via(StaxWriter.flow())
+            .runFold(ByteString.empty(), (s1,s2) -> s1.concat(s2), materializer)
+            .toCompletableFuture().get(1, TimeUnit.SECONDS);
+            
+            assertThat(result.toArray(), isIdenticalTo(Input.fromString(
+                "<prefix:tag xmlns:prefix='uri:ns1'><prefix:tag xmlns:prefix='uri:ns2' xmlns:atprefix='uri:attrns' atprefix:a='hello'/></prefix:tag>")));
+        });
+        
+        it("Should output elements in their respective namespaces when they have no prefix", () -> {
+            XMLEventFactory factory = XMLEventFactory.newFactory();
+            Attribute attr = factory.createAttribute(new QName("uri:attrns", "a", "atprefix"), "hello");
+            ByteString result = Source.from(Arrays.<XMLEvent>asList(
+                factory.createStartElement(new QName("uri:ns1","tag",""), null, null),
+                factory.createStartElement(new QName("uri:ns2","tag",""), Arrays.asList(attr).iterator(), null),
+                factory.createEndElement(new QName("uri:ns2","tag",""), null),
+                factory.createEndElement(new QName("uri:ns1","tag",""), null)
+            ))
+            .via(StaxWriter.flow())
+            .runFold(ByteString.empty(), (s1,s2) -> s1.concat(s2), materializer)
+            .toCompletableFuture().get(1, TimeUnit.SECONDS);
+            
+            assertThat(result.toArray(), isIdenticalTo(Input.fromString(
+                "<tag xmlns='uri:ns1'><tag xmlns='uri:ns2' xmlns:atprefix='uri:attrns' atprefix:a='hello'/></tag>")));
         });
     });
 }}


### PR DESCRIPTION
Currently, the pretty `tag(qname(cac, "AdditionalDocumentReference"))` gets output without any namespace at all. This is because, officially, you have to specify all your namespaces _both_ in the `QName` of the element start tag name, _AND_ in a separate "namespaces" collection on the same event.

We don't want to enburden all tag protocols with needing to register and de-register namespaces. It's smarter to have StaxWriter auto-inject them, so all protocols can just output plain QNames.

@alar17 please review