### PR TITLE
StaxWriter should auto-create namespaces for StartElement events

### DIFF
--- a/ts-reaktive-marshal-akka/src/main/java/com/tradeshift/reaktive/marshal/stream/StaxWriter.java
+++ b/ts-reaktive-marshal-akka/src/main/java/com/tradeshift/reaktive/marshal/stream/StaxWriter.java
@@ -1,10 +1,15 @@
 package com.tradeshift.reaktive.marshal.stream;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventWriter;
 import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.Namespace;
 import javax.xml.stream.events.XMLEvent;
 
 import akka.NotUsed;
@@ -17,6 +22,7 @@ import akka.util.ByteString;
  */
 public class StaxWriter extends PushPullOutputStreamAdapter<List<XMLEvent>, XMLEventWriter> {
     private static final XMLOutputFactory factory = XMLOutputFactory.newInstance();
+    private static final XMLEventFactory evtFactory = XMLEventFactory.newFactory();
     
     /**
      * Returns a flow that buffers up to 100 XML events and writing them together.
@@ -48,10 +54,37 @@ public class StaxWriter extends PushPullOutputStreamAdapter<List<XMLEvent>, XMLE
             (attr, out) -> factory.createXMLEventWriter(out, "UTF-8"),
             (writer, events) -> {
                 for (XMLEvent event: events) {
+                    if (event.isStartElement() && !event.asStartElement().getNamespaces().hasNext()) {
+                        List<Namespace> namespaces = new ArrayList<>();
+                        register(writer, namespaces, event.asStartElement().getName());
+                        
+                        Iterator<?> attributes = event.asStartElement().getAttributes();
+                        while (attributes.hasNext()) {
+                            Attribute attr = (Attribute) attributes.next();
+                            register(writer, namespaces, attr.getName());
+                        }
+                        
+                        if (!namespaces.isEmpty()) {
+                            event = evtFactory.createStartElement(event.asStartElement().getName(), event.asStartElement().getAttributes(), namespaces.iterator());
+                        }
+                    }
                     writer.add(event);
                 }
                 writer.flush();
             }
         );
+    }
+    
+    /**
+     * Adds a namespace mapping for [name] to [namespaces], if it doesn't already exist on [writer].
+     */
+    private static void register(XMLEventWriter writer, List<Namespace> namespaces, QName name) {
+        String nsUri = name.getNamespaceURI();
+        if (nsUri != null && !nsUri.isEmpty()) {
+            String existing = writer.getNamespaceContext().getNamespaceURI(name.getPrefix());
+            if (existing == null || !existing.equals(nsUri)) {
+                namespaces.add(evtFactory.createNamespace(name.getPrefix(), nsUri));
+            }
+        }
     }
 }

--- a/ts-reaktive-marshal-akka/src/test/java/com/tradeshift/reaktive/marshal/stream/StaxWriterSpec.java
+++ b/ts-reaktive-marshal-akka/src/test/java/com/tradeshift/reaktive/marshal/stream/StaxWriterSpec.java
@@ -1,23 +1,27 @@
 package com.tradeshift.reaktive.marshal.stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.forgerock.cuppa.Cuppa.describe;
 import static org.forgerock.cuppa.Cuppa.it;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.XMLEvent;
 
 import org.forgerock.cuppa.junit.CuppaRunner;
 import org.junit.runner.RunWith;
 import org.xmlunit.builder.Input;
 
-import com.tradeshift.reaktive.marshal.stream.StaxWriter;
 import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
 
 import akka.stream.javadsl.Source;
@@ -38,6 +42,42 @@ public class StaxWriterSpec extends SharedActorSystemSpec {{
                 .toCompletableFuture().get(1, TimeUnit.SECONDS);
 
             assertThat(result.toArray(), isIdenticalTo(Input.fromURL(getClass().getResource("/test.xml"))));
+        });
+        
+        it("Should augment startElement events with namespace prefix mappings when they're introduced", () -> {
+            XMLEventFactory factory = XMLEventFactory.newFactory();
+            Attribute attr = factory.createAttribute(new QName("uri:attrns", "a", "atprefix"), "hello");
+            ByteString result = Source.from(Arrays.<XMLEvent>asList(
+                factory.createStartElement(new QName("uri:ns1","tag","prefix"), null, null),
+                factory.createStartElement(new QName("uri:ns2","tag","prefix"), Arrays.asList(attr).iterator(), null),
+                factory.createEndElement(new QName("uri:ns2","tag","prefix"), null),
+                factory.createStartElement(new QName("uri:ns1","tag","prefix"), null, null),
+                factory.createEndElement(new QName("uri:ns1","tag","prefix"), null),
+                factory.createEndElement(new QName("uri:ns1","tag","prefix"), null)
+            ))
+            .via(StaxWriter.flow())
+            .runFold(ByteString.empty(), (s1,s2) -> s1.concat(s2), materializer)
+            .toCompletableFuture().get(1, TimeUnit.SECONDS);
+            
+            assertThat(result.utf8String()).isEqualTo(
+                "<prefix:tag xmlns:prefix=\"uri:ns1\"><prefix:tag xmlns:prefix=\"uri:ns2\" xmlns:atprefix=\"uri:attrns\" atprefix:a=\"hello\"/><prefix:tag/></prefix:tag>");
+        });
+        
+        it("Should output elements in their respective namespaces when they have no prefix", () -> {
+            XMLEventFactory factory = XMLEventFactory.newFactory();
+            Attribute attr = factory.createAttribute(new QName("uri:attrns", "a", "atprefix"), "hello");
+            ByteString result = Source.from(Arrays.<XMLEvent>asList(
+                factory.createStartElement(new QName("uri:ns1","tag",""), null, null),
+                factory.createStartElement(new QName("uri:ns2","tag",""), Arrays.asList(attr).iterator(), null),
+                factory.createEndElement(new QName("uri:ns2","tag",""), null),
+                factory.createEndElement(new QName("uri:ns1","tag",""), null)
+            ))
+            .via(StaxWriter.flow())
+            .runFold(ByteString.empty(), (s1,s2) -> s1.concat(s2), materializer)
+            .toCompletableFuture().get(1, TimeUnit.SECONDS);
+            
+            assertThat(result.toArray(), isIdenticalTo(Input.fromString(
+                "<tag xmlns='uri:ns1'><tag xmlns='uri:ns2' xmlns:atprefix='uri:attrns' atprefix:a='hello'/></tag>")));
         });
     });
 }}


### PR DESCRIPTION
We don't want to enburden all tag protocols with needing to register
and de-register namespaces. It's smarter to have StaxWriter
auto-inject them, so all protocols can just output plain QNames.