### PR TITLE
Backup events to S3, in order to do emergency off-line restore

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,8 @@ lazy val `ts-reaktive-actors` = project.settings(commonSettings: _*).dependsOn(`
 
 lazy val `ts-reaktive-replication` = project.settings(commonSettings: _*).dependsOn(`ts-reaktive-actors`, `ts-reaktive-cassandra`, `ts-reaktive-testkit` % "test")
 
+lazy val `ts-reaktive-backup` = project.settings(commonSettings: _*).dependsOn(`ts-reaktive-replication`, `ts-reaktive-marshal-akka`, `ts-reaktive-testkit` % "test")
+
 lazy val `ts-reaktive-ssl` = project.settings(commonSettings: _*)
 
 lazy val `ts-reaktive-kamon-log4j` = project.settings(commonSettings: _*)
@@ -95,6 +97,7 @@ lazy val root = (project in file(".")).settings(publish := { }, publishLocal := 
   `ts-reaktive-actors`,
   `ts-reaktive-cassandra`,
   `ts-reaktive-replication`,
+  `ts-reaktive-backup`,
   `ts-reaktive-ssl`,
   `ts-reaktive-marshal`,
   `ts-reaktive-marshal-akka`,

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/protobuf/DelimitedProtobufFraming.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/protobuf/DelimitedProtobufFraming.java
@@ -1,0 +1,121 @@
+package com.tradeshift.reaktive.protobuf;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.Message;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+import akka.util.ByteString;
+import scala.Tuple2;
+
+/**
+ * Parses an incoming byte string of "delimited" protobuf messages such, that each ByteString makes
+ * up a complete message.
+ * 
+ * The stream is expected to consist of [Varint length] [length bytes] [Varint length] [length bytes] etc.
+ * This is the format that multiple calls to {@link Message#writeDelimitedTo(java.io.OutputStream)} would produce.
+ * 
+ * The length delimiters themselves are not emitted downstream, i.e. each downstream ByteString can be decoded
+ * using protobuf's "parse" function, not "parseDelimited".
+ */
+public class DelimitedProtobufFraming extends GraphStage<FlowShape<ByteString,ByteString>> {
+    public static final DelimitedProtobufFraming instance = new DelimitedProtobufFraming();
+    
+    private static final Logger log = LoggerFactory.getLogger(DelimitedProtobufFraming.class);
+    
+    private final Inlet<ByteString> in = Inlet.create("in");
+    private final Outlet<ByteString> out = Outlet.create("out");
+    private final FlowShape<ByteString, ByteString> shape = FlowShape.of(in, out);
+    
+    private DelimitedProtobufFraming() {}
+    
+    @Override
+    public FlowShape<ByteString, ByteString> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes attr) throws Exception {
+        return new GraphStageLogic(shape) {
+            ByteString buf = ByteString.empty();
+            {
+                setHandler(in, new AbstractInHandler() {
+                    @Override
+                    public void onPush() {
+                        ByteString b = grab(in);
+                        buf = buf.concat(b);
+                        deliverBuf();
+                    }
+
+                    @Override
+                    public void onUpstreamFinish() {
+                        if (buf.size() > 0) {
+                            deliverBuf();
+                        }
+                        completeStage();
+                    };
+                    
+                    private void deliverBuf() {
+                        log.debug("Buf now {}", buf);
+                        try {
+                            List<ByteString> deframed = new ArrayList<>();
+                            while (buf.size() > 0) {
+                                CodedInputStream i = CodedInputStream.newInstance(buf.iterator().asInputStream());
+                                long contentLength = i.readUInt64();
+                                int delimiterLength = i.getTotalBytesRead();
+                                log.debug("Got content {}, delimiter {}", contentLength, delimiterLength);
+                                if (buf.size() >= delimiterLength + contentLength) {
+                                    buf = buf.drop(delimiterLength); // cast OK, delimiter will be a few bytes at most
+                                    if (contentLength > Integer.MAX_VALUE) {
+                                        throw new IOException("Only support protobuf messages up to 2G each. And that's a lot.");
+                                    }
+                                    Tuple2<ByteString, ByteString> t = buf.splitAt((int)contentLength);
+                                    deframed.add(t._1);
+                                    buf = t._2;
+                                } else {
+                                    // not received enough bytes yet
+                                    break;
+                                }
+                            }
+                            
+                            if (deframed.isEmpty()) {
+                                pull(in);
+                            } else {
+                                emitMultiple(out, deframed.iterator());
+                            }
+                        } catch (IOException x) {
+                            log.debug("Protobuf unhappy at length {}", buf.size());
+                            if (buf.size() < 10) {
+                                // this is possibly because there are not enough bytes to read a full varint. Pull to be safe.
+                                pull(in);
+                            } else {
+                                failStage(x);
+                            }
+                        }
+                    }
+                });
+                
+                setHandler(out, new AbstractOutHandler() {
+                    @Override
+                    public void onPull() {
+                        pull(in);
+                    }
+                });
+            }
+        };
+    }
+
+}

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/protobuf/DelimitedProtobufFramingSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/protobuf/DelimitedProtobufFramingSpec.java
@@ -1,0 +1,53 @@
+package com.tradeshift.reaktive.protobuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
+
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import javaslang.collection.Vector;
+
+@RunWith(CuppaRunner.class)
+public class DelimitedProtobufFramingSpec extends SharedActorSystemSpec {{
+    describe("DelimitedProtobufFraming", () -> {
+        it("should parse multiple protobufs in one chunk", () -> {
+            assertThat(Source
+                .single(ByteString.fromInts(4,0,0,0,0,2,1,1))
+                .via(DelimitedProtobufFraming.instance)
+                .runWith(Sink.seq(), materializer)
+                .toCompletableFuture()
+                .get(1, TimeUnit.SECONDS)
+            ).containsExactly(ByteString.fromInts(0,0,0,0), ByteString.fromInts(1,1));
+        });
+        
+        it("should parse multiple protobufs made up of 1-byte strings", () -> {
+            assertThat(Source
+                .from(Vector.of(4,0,0,0,0,2,1,1).map(i -> ByteString.fromInts(i)))
+                .via(DelimitedProtobufFraming.instance)
+                .runWith(Sink.seq(), materializer)
+                .toCompletableFuture()
+                .get(1, TimeUnit.SECONDS)
+            ).containsExactly(ByteString.fromInts(0,0,0,0), ByteString.fromInts(1,1));
+        });
+        
+        it("should fail on an invalid delimiter once the stream reaches at least 10 bytes", () -> {
+            assertThatThrownBy(() -> Source
+                .single(ByteString.fromInts(255,255,255,255,255,255,255,255,255,255))
+                .via(DelimitedProtobufFraming.instance)
+                .runWith(Sink.seq(), materializer)
+                .toCompletableFuture()
+                .get(1, TimeUnit.SECONDS)
+            ).hasMessageContaining("malformed varint");
+        });
+    });
+}}

--- a/ts-reaktive-actors/src/test/resources/log4j.xml
+++ b/ts-reaktive-actors/src/test/resources/log4j.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration>
+  <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out" />
+    <param name="Threshold" value="DEBUG" />
+    <layout class="org.apache.log4j.EnhancedPatternLayout">
+      <param name="ConversionPattern" value="%d{ABSOLUTE} %-5p [%c{1.}] %X{akkaSource} - %m%n" />
+    </layout>
+  </appender>
+  
+  <logger name="org.apache.cassandra"><level value="WARN" /></logger>
+  <logger name="com.datastax.driver"><level value="WARN" /></logger>
+  <logger name="io.netty"><level value="WARN" /></logger>
+  <logger name="com.tradeshift.documentcore.kamon"><level value="WARN" /></logger>
+  <logger name="Sigar"><level value="WARN"/></logger>
+  <logger name="org.apache.http"><level value="WARN"/></logger>
+  <logger name="org.mortbay"><level value="WARN"/></logger>
+  <logger name="akka"><level value="DEBUG"/></logger>
+  <logger name="org.apache.sshd"><level value="INFO"/></logger>
+  <logger name="org.apache.sshd.server.subsystem.sftp"><level value="DEBUG"/></logger>
+  
+  <!-- These are to get rid of the "Column family ID mismatch" errors during test startup -->
+  <logger name="org.apache.cassandra.service.CassandraDaemon"><level value="FATAL"/></logger>
+  <logger name="org.apache.cassandra.transport.Message"><level value="FATAL"/></logger>
+  <logger name="org.apache.cassandra.transport.Message"><level value="FATAL"/></logger>
+  <logger name="org.apache.cassandra.transport.messages.ErrorMessage"><level value="FATAL"/></logger>
+  
+  <root>
+    <priority value="DEBUG" />
+    <appender-ref ref="CONSOLE" />
+  </root>
+</log4j:configuration>

--- a/ts-reaktive-backup/build.sbt
+++ b/ts-reaktive-backup/build.sbt
@@ -1,0 +1,36 @@
+import sbtprotobuf.{ProtobufPlugin=>PB}
+
+description := "Backup and restore for datacenter-aware replicated actors"
+
+// Do not append Scala versions to the generated artifacts
+crossPaths := false
+
+// This forbids including Scala related libraries into the dependency
+autoScalaLibrary := false
+
+// Make this a Java-only project in Eclipse
+EclipseKeys.projectFlavor := EclipseProjectFlavor.Java
+
+// Because of https://github.com/cuppa-framework/cuppa/pull/113
+parallelExecution in Test := false
+
+PB.includePaths in PB.protobufConfig += file("ts-reaktive-actors/src/main/protobuf")
+
+// library dependencies. (organization name) % (project name) % (version) % (scope)
+libraryDependencies ++= {
+  Seq(
+    "com.bluelabs" %% "s3-stream" % "0.0.3",
+    "junit" % "junit" % "4.11" % "test",
+    "org.assertj" % "assertj-core" % "3.2.0" % "test",
+    "org.mockito" % "mockito-core" % "1.10.19" % "test",
+    "info.solidsoft.mockito" % "mockito-java8" % "0.3.0" % "test",
+    "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.3.0" % "test",
+    "com.novocode" % "junit-interface" % "0.11" % "test",
+    "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
+    "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",
+    "org.apache.cassandra" % "cassandra-all" % "3.0.3" % "test" exclude("ch.qos.logback", "logback-classic"),
+    "com.github.tomakehurst" % "wiremock" % "1.58" % "test"
+  )
+}
+
+fork in Test := true

--- a/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/DropUntilNext.java
+++ b/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/DropUntilNext.java
@@ -1,0 +1,91 @@
+package com.tradeshift.reaktive.backup;
+
+import java.util.function.Predicate;
+
+import akka.stream.Attributes;
+import akka.stream.FlowShape;
+import akka.stream.Inlet;
+import akka.stream.Outlet;
+import akka.stream.stage.AbstractInHandler;
+import akka.stream.stage.AbstractOutHandler;
+import akka.stream.stage.GraphStage;
+import akka.stream.stage.GraphStageLogic;
+
+/**
+ * Stage that drops incoming elements, until it finds one that matches the predicate, but starts
+ * output with the element BEFORE the one matching the predicate.
+ * 
+ * In other words, it drops elements until the NEXT element matches the predicate.
+ */
+public class DropUntilNext<T> extends GraphStage<FlowShape<T,T>> {
+    /**
+     * Returns a DropUntilNext.
+     * @param includeLastIfNoMatch Whether to emit the last element if the stream is about to end without
+     * anything having matched the predicate.
+     */
+    public static <T> GraphStage<FlowShape<T,T>> dropUntilNext(Predicate<T> predicate, boolean includeLastIfNoMatch) {
+        return new DropUntilNext<>(predicate, includeLastIfNoMatch);
+    }
+    
+    private final Inlet<T> in = Inlet.create("in");
+    private final Outlet<T> out = Outlet.create("out");
+    private final FlowShape<T,T> shape = FlowShape.of(in, out);
+    
+    private final Predicate<T> predicate;
+    private final boolean includeLastIfNoMatch;
+    
+    public DropUntilNext(Predicate<T> predicate, boolean includeLastIfNoMatch) {
+        this.predicate = predicate;
+        this.includeLastIfNoMatch = includeLastIfNoMatch;
+    }
+
+    @Override
+    public FlowShape<T, T> shape() {
+        return shape;
+    }
+
+    @Override
+    public GraphStageLogic createLogic(Attributes attr) throws Exception {
+        return new GraphStageLogic(shape) {
+            boolean open = false;
+            T last = null;
+            {
+                setHandler(in, new AbstractInHandler() {
+                    @Override
+                    public void onPush() {
+                        T t = grab(in);
+                        if (open) {
+                            push(out, last);
+                        } else if (predicate.test(t)) {
+                            open = true;
+                            if (last != null) {
+                                push(out, last);
+                            } else {
+                                pull(in);
+                            }
+                        } else {
+                            pull(in);
+                        }
+                        last = t;
+                    }
+                    
+                    @Override
+                    public void onUpstreamFinish() {
+                        if ((open || includeLastIfNoMatch) && last != null) {
+                            emit(out, last);
+                        }
+                        completeStage();
+                    };
+                });
+                
+                setHandler(out, new AbstractOutHandler() {
+                    @Override
+                    public void onPull() {
+                        pull(in);
+                    }
+                });
+            }
+        };
+    }
+
+}

--- a/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3.java
+++ b/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3.java
@@ -1,0 +1,336 @@
+package com.tradeshift.reaktive.backup;
+
+import static com.tradeshift.reaktive.marshal.Protocol.option;
+import static com.tradeshift.reaktive.marshal.Protocol.vector;
+import static com.tradeshift.reaktive.xml.XMLProtocol.body;
+import static com.tradeshift.reaktive.xml.XMLProtocol.ns;
+import static com.tradeshift.reaktive.xml.XMLProtocol.qname;
+import static com.tradeshift.reaktive.xml.XMLProtocol.tag;
+import static javaslang.control.Option.none;
+import static javaslang.control.Option.some;
+import static scala.compat.java8.FutureConverters.toJava;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.XMLEvent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.bluelabs.akkaaws.AWSCredentials$;
+import com.bluelabs.akkaaws.BasicCredentials;
+import com.bluelabs.akkaaws.CredentialScope;
+import com.bluelabs.akkaaws.Signer;
+import com.bluelabs.akkaaws.SigningKey;
+import com.bluelabs.s3stream.CompleteMultipartUploadResult;
+import com.bluelabs.s3stream.HttpRequests;
+import com.bluelabs.s3stream.S3Location;
+import com.bluelabs.s3stream.S3Stream;
+import com.tradeshift.reaktive.marshal.ReadProtocol;
+import com.tradeshift.reaktive.marshal.StringMarshallable;
+import com.tradeshift.reaktive.marshal.stream.AaltoReader;
+import com.tradeshift.reaktive.marshal.stream.ProtocolReader;
+import com.tradeshift.reaktive.protobuf.DelimitedProtobufFraming;
+import com.tradeshift.reaktive.protobuf.EventEnvelopeSerializer;
+import com.typesafe.config.Config;
+
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.http.impl.model.JavaUri;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.model.HttpMethods;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.Query;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.Uri;
+import akka.http.javadsl.model.headers.Host;
+import akka.http.javadsl.unmarshalling.Unmarshaller;
+import akka.japi.Pair;
+import akka.persistence.query.EventEnvelope;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.util.ByteString;
+import akka.util.ByteStringBuilder;
+import javaslang.collection.Seq;
+import javaslang.collection.Vector;
+import javaslang.control.Option;
+import scala.concurrent.Future;
+
+/**
+ * Small wrapper atop https://github.com/bluelabsio/s3-stream
+ */
+public class S3 {
+    /**
+     * S3 key names are {bucketKeyPrefix}{tag}{SEPARATOR}{time of first event}
+     */
+    private static final String SEPARATOR = "-from-";
+    /**
+     * The time of event in the S3 key name is formatted as uuuu_MM_dd_HH_mm_ss_SSS. This pattern was selected for several reasons:
+     * - Encoding ":" yields URL encoding issues when calculating the S3 signature of the upload
+     * - Leaving out "_" causes java's DateTimeFormatter to no longer being able to parse the date.
+     * - DateTimeFormatter.ofPattern screws up royally when using "SSS"
+     */
+    private static final DateTimeFormatter FMT = new DateTimeFormatterBuilder()
+        .appendValue(ChronoField.YEAR_OF_ERA, 4)
+        .appendLiteral('_')
+        .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+        .appendLiteral('_')
+        .appendValue(ChronoField.DAY_OF_MONTH, 2)
+        .appendLiteral('_')
+        .appendValue(ChronoField.HOUR_OF_DAY, 2)
+        .appendLiteral('_')
+        .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+        .appendLiteral('_')
+        .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+        .appendLiteral('_')
+        .appendValue(ChronoField.MILLI_OF_SECOND, 3)
+        .toFormatter().withZone(ZoneId.of("UTC"));
+
+    static {
+        Instant now = Instant.now();
+        System.out.println(now.toEpochMilli());
+        System.out.println(FMT.format(now));
+    }
+    
+    private static final Logger log = LoggerFactory.getLogger(S3.class);
+    
+    private final String bucket;
+    private final String bucketKeyPrefix;
+    private final BasicCredentials creds;
+    private final String region;
+    private final Materializer materializer;
+    private final Http http;
+    private final ActorSystem system;
+    private final EventEnvelopeSerializer serializer;
+
+    public S3(ActorSystem system, Config config, Materializer materializer, Http http, EventEnvelopeSerializer serializer) {
+        this.system = system;
+        this.materializer = materializer;
+        this.http = http;
+        this.serializer = serializer;
+        Config s3Config = config.getConfig("s3");
+        bucket = s3Config.getString("bucket");
+        String prefix = s3Config.getString("bucket-key-prefix");
+        bucketKeyPrefix = prefix.endsWith("/") ? prefix : prefix + "/";
+        creds = AWSCredentials$.MODULE$.apply(s3Config.getString("key"), s3Config.getString("secret"));
+        region = s3Config.getString("region");
+    }
+    
+    /**
+     * Stores the given buffered events into S3, under a key that includes the tag and the offset of the first event.
+     * @param tag Persistence tag that the events were for
+     */
+    public CompletionStage<Done> store(String tag, Seq<EventEnvelope> events) {
+        String key = tag + SEPARATOR + FMT.format(Instant.ofEpochMilli(events.get(0).offset()));
+        return Source.from(events)
+              .map(e -> {
+                  ByteStringBuilder b = new ByteStringBuilder();
+                  serializer.toProtobuf(e).writeDelimitedTo(b.asOutputStream());
+                  return b.result();
+              })
+              .runWith(upload(key), materializer)
+              .thenApply(result -> {
+                  log.info("Uploaded to {} with etag {}", result.key(), result.etag());
+                  return Done.getInstance();
+              });
+    }
+    
+    /**
+     * Returns the instant of the first event saved under the given entry, by parsing its key name.
+     */
+    public static Instant getStartInstant(S3Entry entry) {
+        int i = entry.getKey().lastIndexOf(SEPARATOR);
+        if (i == -1) throw new IllegalArgumentException("Expected " + entry.getKey() + " to contain " + SEPARATOR);
+        return FMT.parse(entry.getKey().substring(i + SEPARATOR.length()), Instant::from);
+    }
+    
+    /**
+     * Loads the last known written offset from S3, or returns 0 if not found
+     */
+    public CompletionStage<Long> loadOffset() {
+        return download("_lastOffset").thenCompose(opt -> {
+            if (opt.isEmpty()) {
+                return CompletableFuture.completedFuture(0l);
+            } else {
+                return opt.get().runFold(ByteString.empty(), ByteString::concat, materializer)
+                                .thenApply(bs -> Long.parseLong(bs.utf8String()));
+            }
+        });
+    }
+    
+    /**
+     * Writes the last known offset to S3
+     */
+    public CompletionStage<Done> saveOffset(long offset) {
+        return Source.single(ByteString.fromString(String.valueOf(offset)))
+                     .runWith(upload("_lastOffset"), materializer)
+                     .thenApply(result -> Done.getInstance());
+    }
+    
+    private Sink<ByteString, CompletionStage<CompleteMultipartUploadResult>> upload(String key) {
+        S3Location s3Location = toLocation(key);
+        log.debug("Uploading to {}", s3Location);
+        return s3stream()
+            .multipartUpload(s3Location, 5242880, 1)
+            .asJava()
+            .mapMaterializedValue(f -> toJava(f));
+    }
+
+    private S3Location toLocation(String key) {
+        return S3Location.apply(bucket, bucketKeyPrefix + key);
+    }
+    
+    private S3Stream s3stream() {
+        return new S3Stream(creds, region, system, materializer);
+    }
+    
+    private CompletionStage<Option<Source<ByteString,NotUsed>>> download(String key) {
+        S3Location s3Location = toLocation(key);
+        log.debug("Downloading from {}", s3Location);
+        SigningKey signingKey = SigningKey.apply(creds, CredentialScope.apply(LocalDate.now(), region, "s3"), SigningKey.apply$default$3());
+        
+        Future<akka.http.scaladsl.model.HttpRequest> request = Signer.signedRequest(
+            (akka.http.scaladsl.model.HttpRequest)
+            HttpRequest.create()
+            .withMethod(HttpMethods.GET)
+            .withUri(new JavaUri(HttpRequests.requestUri(s3Location)))
+            .addHeader(Host.create(HttpRequests.requestHost(s3Location).address()))
+        , signingKey, Signer.signedRequest$default$3(), materializer);
+        
+        return toJava(request)
+            .thenCompose(rq -> http.singleRequest(rq, materializer))
+            .thenCompose(rs -> {
+                return getOptionBody(rs);
+        });
+    }
+
+    private CompletionStage<Option<Source<ByteString, NotUsed>>> getOptionBody(HttpResponse rs) {
+        log.debug("Got a response: {}", rs);
+        if (rs.status().equals(StatusCodes.NOT_FOUND)) {
+            return CompletableFuture.completedFuture(Option.none());
+        } else if (rs.status().isFailure()) {
+            return
+                Unmarshaller.entityToString().unmarshall(rs.entity(), system.dispatcher(), materializer)
+                .thenApply(msg -> {throw new IllegalStateException ("S3 request failed: " + msg);});
+        } else {
+            return CompletableFuture.completedFuture(Option.some(rs.entity().getDataBytes().mapMaterializedValue(o -> NotUsed.getInstance())));
+        }
+    }
+
+    static class S3ListResponse {
+        private final Option<String> nextContinuationToken;
+        private final Seq<S3Entry> entries;
+        
+        public S3ListResponse(Option<String> nextContinuationToken, Seq<S3Entry> entries) {
+            this.nextContinuationToken = nextContinuationToken;
+            this.entries = entries;
+        }
+        
+        public Seq<S3Entry> getEntries() {
+            return entries;
+        }
+        
+        public Option<String> getNextContinuationToken() {
+            return nextContinuationToken;
+        }
+
+        private static final Namespace NS = ns("http://s3.amazonaws.com/doc/2006-03-01/");
+        static final ReadProtocol<XMLEvent,S3ListResponse> proto =
+            tag(qname(NS, "ListBucketResult"),
+                option(
+                    tag(qname(NS, "ContinuationToken"), body)
+                ),
+                vector(
+                    tag(qname(NS, "Contents"),
+                        tag(qname(NS, "Key"), body),
+                        tag(qname(NS, "LastModified"), body.as(StringMarshallable.INSTANT)),
+                        tag(qname(NS, "Size"), body.as(StringMarshallable.LONG)),
+                        S3Entry::new
+                    )
+                ),
+                S3ListResponse::new
+            );
+    }
+        
+    public Source<S3Entry, NotUsed> list(String keyPrefix) {
+        return Source.<String,Seq<S3Entry>>unfoldAsync("", continuationToken -> {
+            if (continuationToken.equals("done")) {
+                return CompletableFuture.completedFuture(Optional.empty());
+            } else {
+                return list(keyPrefix, continuationToken.isEmpty() ? none() : some(continuationToken))
+                    .thenApply(response -> {
+                        if (response.nextContinuationToken.isDefined()) {
+                            return Optional.of(Pair.create(response.nextContinuationToken.get(), response.entries));
+                        } else {
+                            return Optional.of(Pair.create("done", response.entries));
+                        }
+                    });
+            }
+        }).flatMapConcat(seq -> Source.from(seq));
+    }
+    
+    private CompletionStage<S3ListResponse> list(String keyPrefix, Option<String> continuationToken) {
+        S3Location s3Location = toLocation(keyPrefix);
+        log.debug("Listing {}", s3Location);
+        SigningKey signingKey = SigningKey.apply(creds, CredentialScope.apply(LocalDate.now(), region, "s3"), SigningKey.apply$default$3());
+        
+        Future<akka.http.scaladsl.model.HttpRequest> request = Signer.signedRequest(
+            (akka.http.scaladsl.model.HttpRequest)
+            HttpRequest.create()
+            .withMethod(HttpMethods.GET)
+            .withUri(Uri.create("http://" + HttpRequests.requestHost(s3Location).address() + "/").query(Query.create(
+                Vector.of(
+                    Pair.create("list-type", "2"),
+                    // TODO max return size configurable, default to 1000 is fine
+                    Pair.create("prefix", bucketKeyPrefix + keyPrefix)
+                ).appendAll(continuationToken.map(s ->
+                    Pair.create("continuation-token", s)
+                ))
+            )))
+            .addHeader(Host.create(HttpRequests.requestHost(s3Location).address()))
+        , signingKey, Signer.signedRequest$default$3(), materializer);
+        
+        return Source.fromCompletionStage(toJava(request)
+            .thenCompose(rq -> http.singleRequest(rq, materializer))
+            .thenCompose(this::getOptionBody))
+            .flatMapConcat(opt -> {
+                if (opt.isDefined()) {
+                    log.debug("Parsing S3 bucket list starting.");
+                    return opt.get();
+                } else {
+                    log.warn("Huh, empty body for S3 list?");
+                    return Source.<ByteString>empty();
+                }
+            })
+            .log("list-" + keyPrefix, bs -> bs.utf8String())
+            .via(AaltoReader.instance)
+            .via(ProtocolReader.of(S3ListResponse.proto))
+            .runWith(Sink.head(), materializer);
+            
+            
+    }
+
+    /**
+     * Reads the stream of events written to S3 using {@link #store(String, List)} before.
+     */
+    public Source<com.tradeshift.reaktive.protobuf.Query.EventEnvelope, NotUsed> loadEvents(String key) {
+        return Source.fromCompletionStage(
+            download(key).thenApply(opt -> opt.getOrElse(Source.empty()))
+        ).flatMapConcat(src -> src)
+        .via(DelimitedProtobufFraming.instance)
+        .map(bs -> com.tradeshift.reaktive.protobuf.Query.EventEnvelope.parseFrom(bs.iterator().asInputStream()));
+    }
+}

--- a/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Backup.java
+++ b/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Backup.java
@@ -1,0 +1,108 @@
+package com.tradeshift.reaktive.backup;
+
+import static akka.pattern.PatternsCS.pipe;
+
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.tradeshift.reaktive.akka.SharedActorMaterializer;
+import com.typesafe.config.Config;
+
+import akka.Done;
+import akka.actor.AbstractActor;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.Status.Failure;
+import akka.cluster.singleton.ClusterSingletonManager;
+import akka.cluster.singleton.ClusterSingletonManagerSettings;
+import akka.japi.pf.ReceiveBuilder;
+import akka.pattern.Backoff;
+import akka.pattern.BackoffSupervisor;
+import akka.persistence.query.javadsl.EventsByTagQuery;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Sink;
+import javaslang.collection.Vector;
+import scala.PartialFunction;
+import scala.concurrent.duration.Duration;
+import scala.concurrent.duration.FiniteDuration;
+import scala.runtime.BoxedUnit;
+
+/**
+ * Makes a continuous backup of events onto an S3 bucket, grouping events into keys of predefined batch sizes.
+ * 
+ * Backup progress is stored on S3 as well.
+ */
+public class S3Backup extends AbstractActor {
+    /**
+     * Starts a ClusterSingletonManager + BackoffSupervisor that manages a continous backup to S3, restarting
+     * and resuming automatically on crash or failure.
+     * 
+     * @param system The actor system to create the singleton for
+     * @param query The akka persistence query journal to read events from
+     * @param tag Tag to pass to the above query
+     * @param s3 Service interface to communicate with S3
+     */
+    public static void start(ActorSystem system, EventsByTagQuery query, String tag, S3 s3) {
+        system.actorOf(ClusterSingletonManager.props(
+            BackoffSupervisor.props(
+                Backoff.onFailure(
+                    Props.create(S3Backup.class, () -> new S3Backup(query, tag, s3)),
+                    "a",
+                    Duration.create(1, TimeUnit.SECONDS),
+                    Duration.create(1, TimeUnit.SECONDS), // TODO make these 3 configurable
+                    0.2)
+            ),
+            Done.getInstance(),
+            ClusterSingletonManagerSettings.create(system).withSingletonName("s")), "s3backup");
+    }
+    
+    private static final Logger log = LoggerFactory.getLogger(S3Backup.class);
+    
+    private final Materializer materializer = SharedActorMaterializer.get(context().system());
+    private final EventsByTagQuery query;
+    private final String tag;
+    private final S3 s3;
+    private final int eventChunkSize;
+    private final FiniteDuration eventChunkDuration;
+    
+    public S3Backup(EventsByTagQuery query, String tag, S3 s3) {
+        this.query = query;
+        this.tag = tag;
+        this.s3 = s3;
+        
+        Config backupCfg = context().system().settings().config().getConfig("ts-reaktive.backup.backup");
+        eventChunkSize = backupCfg.getInt("event-chunk-max-size");
+        eventChunkDuration = FiniteDuration.create(backupCfg.getDuration("event-chunk-max-duration", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+        
+        pipe(s3.loadOffset(), context().dispatcher()).to(self());
+        
+        receive(ReceiveBuilder
+            .match(Long.class, offset -> {
+                context().become(startBackup(offset));
+            })
+            .build());
+    }
+
+    private PartialFunction<Object, BoxedUnit> startBackup(long offset) {
+        query
+            .eventsByTag(tag, 0)
+            // create backups of max [N] elements, or at least every [T] on activity
+            // FIXME write a stage that, instead of buffering each chunk into memory, creates sub-streams instead.
+            .groupedWithin(eventChunkSize, eventChunkDuration)
+            .filter(list -> list.size() > 0)
+            .mapAsync(4, list -> s3.store(tag, Vector.ofAll(list)).thenApply(done -> list.get(list.size() - 1).offset()))
+            .runWith(Sink.actorRefWithAck(self(), "init", "ack", "done", Failure::new), materializer);
+        
+        return ReceiveBuilder
+            .matchEquals("init", msg -> sender().tell("ack", self()))
+            .match(Long.class, l -> pipe(s3.saveOffset(l).thenApply(done -> "ack"), context().dispatcher()).to(sender()))
+            .match(Failure.class, msg -> {
+                log.error("Stream failed, rethrowing", msg.cause());
+                throw new RuntimeException(msg.cause());
+            })
+            .matchEquals("done", msg -> { throw new IllegalStateException("eventsByTag completed, this should not happen. Killing actor, hoping for restart"); })
+            .build();
+    }
+}

--- a/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Entry.java
+++ b/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Entry.java
@@ -1,0 +1,66 @@
+package com.tradeshift.reaktive.backup;
+
+import java.time.Instant;
+
+public class S3Entry {
+    private final String key;
+    private final Instant lastModified;
+    private final long size;
+    
+    public S3Entry(String key, Instant lastModified, long size) {
+        this.key = key;
+        this.lastModified = lastModified;
+        this.size = size;
+    }
+    
+    public String getKey() {
+        return key;
+    }
+    
+    public Instant getLastModified() {
+        return lastModified;
+    }
+    
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public String toString() {
+        return "S3Entry [key=" + key + ", lastModified=" + lastModified + ", size=" + size + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + ((lastModified == null) ? 0 : lastModified.hashCode());
+        result = prime * result + (int) (size ^ (size >>> 32));
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        S3Entry other = (S3Entry) obj;
+        if (key == null) {
+            if (other.key != null)
+                return false;
+        } else if (!key.equals(other.key))
+            return false;
+        if (lastModified == null) {
+            if (other.lastModified != null)
+                return false;
+        } else if (!lastModified.equals(other.lastModified))
+            return false;
+        if (size != other.size)
+            return false;
+        return true;
+    }
+}

--- a/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Restore.java
+++ b/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Restore.java
@@ -1,0 +1,123 @@
+package com.tradeshift.reaktive.backup;
+
+import static com.tradeshift.reaktive.backup.DropUntilNext.dropUntilNext;
+import static akka.pattern.PatternsCS.ask;
+
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.tradeshift.reaktive.akka.SharedActorMaterializer;
+import com.tradeshift.reaktive.replication.actors.ReplicatedActorSharding;
+import com.typesafe.config.Config;
+
+import akka.actor.ActorRef;
+import akka.actor.Status.Failure;
+import akka.japi.pf.ReceiveBuilder;
+import akka.persistence.AbstractPersistentActor;
+import akka.persistence.RecoveryCompleted;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Sink;
+import akka.util.Timeout;
+import scala.PartialFunction;
+import scala.concurrent.duration.FiniteDuration;
+import scala.runtime.BoxedUnit;
+
+/**
+ * Restores from an S3 bucket that S3Backup has written to.
+ * 
+ * It maintains progress as a persistent actor, deleting all but the most recent message, and only
+ * creating an update once every minute. That should keep it in check, without needing to have
+ * this depend on the file system or a specific storage implementation (e.g. cassandra)
+ */
+public class S3Restore extends AbstractPersistentActor {
+    private static final Logger log = LoggerFactory.getLogger(S3Restore.class);
+    
+    private final Materializer materializer = SharedActorMaterializer.get(context().system());
+    private final int maxInFlight;
+    private final Timeout timeout;
+    private final S3 s3;
+    private final String tag;
+    private final ActorRef shardRegion;
+    private final FiniteDuration updateAccuracy;
+    
+    private long offset = 0;
+    
+    /**
+     * Creates a new S3Restore actor. Restoration will start/resume immediately. When restore is complete, the
+     * actor will stop.
+     * 
+     * @param s3 Repository to read from S3
+     * @param tag Tag with which all events should be tagged
+     * @param shardRegion {@link ReplicatedActorSharding} to talk to
+     */
+    public S3Restore(S3 s3, String tag, ActorRef shardRegion) {
+        this.s3 = s3;
+        this.tag = tag;
+        this.shardRegion = shardRegion;
+        
+        Config config = context().system().settings().config().getConfig("ts-reaktive.backup.restore");
+        maxInFlight = config.getInt("maxInFlight");
+        timeout = Timeout.apply(config.getDuration("timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+        updateAccuracy = FiniteDuration.create(config.getDuration("update-accuracy", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+    }
+    
+    @Override
+    public PartialFunction<Object, BoxedUnit> receiveCommand() {
+        return ReceiveBuilder
+            .matchEquals("init", msg -> sender().tell("ack", self()))
+            .match(Long.class, o -> {
+                log.debug("Persisting {}", o);
+                persist(o, done -> {
+                    offset = o;
+                    if (lastSequenceNr() > 1) {
+                        deleteMessages(lastSequenceNr() - 1);
+                    }
+                    context().system().scheduler().scheduleOnce(updateAccuracy, sender(), "ack", context().dispatcher(), self());
+                });
+            })
+            .match(Failure.class, msg -> {
+                log.error("Stream failed, rethrowing", msg.cause());
+                throw new RuntimeException(msg.cause());
+            })
+            .matchEquals("done", msg -> {
+                log.debug("Completed, with offset now {}", offset);
+                context().stop(self());
+            })
+            .build();
+    }
+
+    @Override
+    public PartialFunction<Object, BoxedUnit> receiveRecover() {
+        return ReceiveBuilder
+            .match(Long.class, o -> offset = o)
+            .match(RecoveryCompleted.class, msg -> startRestore())
+            .build();
+    }
+
+    @Override
+    public String persistenceId() {
+        return "s3restore";
+    }
+    
+    private void startRestore() {
+        s3
+        .list(tag)
+        // skip over entries until the one BEFORE entry where startTime >= offset (since the one before may have been only partially restored)
+        .via(dropUntilNext(l -> S3.getStartInstant(l).toEpochMilli() >= offset, true))
+        .flatMapConcat(entry -> s3.loadEvents(entry.getKey().substring(entry.getKey().lastIndexOf("/") + 1)))
+        .mapAsync(maxInFlight, e -> {
+            log.debug("Replaying {}:{}", e.getPersistenceId(), e.getSequenceNr());
+            return ask(shardRegion, e, timeout);
+        })
+        .map(resp -> {
+            log.debug("Responded {}", resp);
+            return (Long) resp;
+        })
+        // only save one lastOffset update per minute, and only the lowest one
+        .conflate((Long l1, Long l2) -> l1 < l2 ? l1 : l2)
+        .runWith(Sink.actorRefWithAck(self(), "init", "ack", "done", Failure::new), materializer);
+    }
+    
+}

--- a/ts-reaktive-backup/src/main/resources/reference.conf
+++ b/ts-reaktive-backup/src/main/resources/reference.conf
@@ -1,0 +1,24 @@
+ts-reaktive {
+  backup {
+    backup {
+      # maximum number of events to put into one chunk onto s3
+      event-chunk-max-size = 10000
+      
+      # maximum time to let pass before starting a new chunk onto s3 (even if less events than above)
+      event-chunk-max-duration = 1 minute
+    }
+  
+    restore {
+      # maximum number of events to send out to persistent actors simultaneously
+      maxInFlight = 100
+      
+      # how long to wait for each persistentactor to process (persist) the received event
+      timeout = 1 minute
+      
+      # updates to "lastOffset" are only written this often. 
+      # Decrease value to get more accurate resuming on failed restores.
+      # Increase value to generate less events on the "s3restore" actor itself.
+      update-accuracy = 1 minute
+    }
+  }
+}

--- a/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/DropUntilNextSpec.java
+++ b/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/DropUntilNextSpec.java
@@ -1,0 +1,58 @@
+package com.tradeshift.reaktive.backup;
+
+import static com.tradeshift.reaktive.backup.DropUntilNext.dropUntilNext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
+
+import akka.NotUsed;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+
+@RunWith(CuppaRunner.class)
+public class DropUntilNextSpec extends SharedActorSystemSpec {
+    {
+        describe("DropUntilNext", () -> {
+            final Source<Integer,NotUsed> from1to10to1 = Source.from(Arrays.asList(1,2,3,4,5,6,7,8,9,10,9,8,7,6,5,4,3,2,1));
+            
+            it("should drop elements until one before the predicate", () -> {
+                assertThat(
+                    from1to10to1.via(dropUntilNext(i -> i >= 5, false)).runWith(Sink.seq(), materializer).toCompletableFuture().get(1, TimeUnit.SECONDS)
+                ).containsExactly(4,5,6,7,8,9,10,9,8,7,6,5,4,3,2,1);
+            });
+            
+            it("should emit the last 2 if the last element matches the predicate", () -> {
+                assertThat(
+                    from1to10to1.via(dropUntilNext(i -> i >= 10, false)).runWith(Sink.seq(), materializer).toCompletableFuture().get(1, TimeUnit.SECONDS)
+                ).containsExactly(9,10,9,8,7,6,5,4,3,2,1);
+                
+            });
+            
+            it("should emit nothing if nothing matches the predicate and includeLastIfNoMatch is false", () -> {
+                assertThat(
+                    Source.range(1,10).via(dropUntilNext(i -> i > 10, false)).runWith(Sink.seq(), materializer).toCompletableFuture().get(1, TimeUnit.SECONDS)
+                ).isEmpty();
+            });
+            
+            it("should emit the last element if nothing matches the predicate and includeLastIfNoMatch is true", () -> {
+                assertThat(
+                    Source.range(1,10).via(dropUntilNext(i -> i > 10, true)).runWith(Sink.seq(), materializer).toCompletableFuture().get(1, TimeUnit.SECONDS)
+                ).containsExactly(10);
+            });
+            
+            it("should emit everything if the first element matches the predicate", () -> {
+                assertThat(
+                    from1to10to1.via(dropUntilNext(i -> i >= 0, false)).runWith(Sink.seq(), materializer).toCompletableFuture().get(1, TimeUnit.SECONDS)
+                ).containsExactly(1,2,3,4,5,6,7,8,9,10,9,8,7,6,5,4,3,2,1);
+            });
+        });
+    }
+}

--- a/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/S3BackupSpec.java
+++ b/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/S3BackupSpec.java
@@ -1,0 +1,111 @@
+package com.tradeshift.reaktive.backup;
+
+import static com.tradeshift.reaktive.testkit.Await.within;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.forgerock.cuppa.Cuppa.beforeEach;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
+import com.typesafe.config.ConfigFactory;
+
+import akka.Done;
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.persistence.query.EventEnvelope;
+import akka.persistence.query.javadsl.EventsByTagQuery;
+import akka.stream.javadsl.Source;
+import akka.testkit.JavaTestKit;
+import javaslang.collection.Vector;
+
+@RunWith(CuppaRunner.class)
+public class S3BackupSpec extends SharedActorSystemSpec {
+    private final EventsByTagQuery query = mock(EventsByTagQuery.class);
+    private final S3 s3 = mock(S3.class);
+    
+    public S3BackupSpec() {
+        super(ConfigFactory.parseString(
+            "ts-reaktive.backup.backup.event-chunk-max-size = 2\n"
+          + "ts-reaktive.backup.backup.event-chunk-max-duration = 1 second\n"));
+    }
+
+    private ActorRef actor() {
+        return system.actorOf(Props.create(S3Backup.class, () -> new S3Backup(query, "tag", s3)));
+    }
+    
+    {
+        describe("The S3Backup actor", () -> {
+            beforeEach(() -> {
+                reset(query, s3);
+                when(s3.loadOffset()).thenReturn(completedFuture(0l));
+                when(s3.saveOffset(anyLong())).thenReturn(completedFuture(Done.getInstance()));
+            });
+            
+            it("stops itself if the query stream ends", () -> {
+                when(query.eventsByTag("tag", 0)).thenReturn(Source.empty());
+                
+                ActorRef actor = actor();
+                
+                JavaTestKit probe = new JavaTestKit(system);
+                probe.watch(actor);
+                probe.expectTerminated(actor);
+            });
+            
+            it("stops itself if the query stream fails", () -> {
+                when(query.eventsByTag("tag", 0)).thenReturn(Source.failed(new RuntimeException("simulated failure")));
+                
+                ActorRef actor = actor();
+                
+                JavaTestKit probe = new JavaTestKit(system);
+                probe.watch(actor);
+                probe.expectTerminated(actor);
+            });
+            
+            it("uploads a chunk after the specified chunk interval elapses", () -> {
+                EventEnvelope envelope1 = EventEnvelope.apply(0, "persistenceId", 0, "hello, world");
+                
+                CompletableFuture<EventEnvelope> event1 = new CompletableFuture<>();
+                CompletableFuture<EventEnvelope> event2 = new CompletableFuture<>();
+                when(query.eventsByTag("tag", 0)).thenReturn(Source.fromCompletionStage(event1).concat(Source.fromCompletionStage(event2)));
+                when(s3.store("tag", Vector.of(envelope1))).thenReturn(completedFuture(Done.getInstance()));
+                
+                actor();
+                event1.complete(envelope1);
+                Thread.sleep(1500);
+                
+                verify(s3).store("tag", Vector.of(envelope1));
+            });
+            
+            it("uploads a chunk after the specified number of events, even if the interval hasn't elapsed yet", () -> {
+                EventEnvelope envelope1 = EventEnvelope.apply(0, "persistenceId", 0, "hello, world");
+                EventEnvelope envelope2 = EventEnvelope.apply(1, "persistenceId", 1, "hello, world");
+                
+                CompletableFuture<EventEnvelope> event1 = new CompletableFuture<>();
+                CompletableFuture<EventEnvelope> event2 = new CompletableFuture<>();
+                CompletableFuture<EventEnvelope> event3 = new CompletableFuture<>();
+                when(query.eventsByTag("tag", 0)).thenReturn(Source.fromCompletionStage(event1).concat(Source.fromCompletionStage(event2)).concat(Source.fromCompletionStage(event3)));
+                when(s3.store("tag", Vector.of(envelope1, envelope2))).thenReturn(completedFuture(Done.getInstance()));
+                
+                actor();
+                event1.complete(envelope1);
+                event2.complete(envelope2);
+
+                // before event-chunk-max-duration, the events should have been stored
+                within(500, TimeUnit.MILLISECONDS).eventuallyDo(() -> {
+                    verify(s3).store("tag", Vector.of(envelope1, envelope2));
+                });
+            });
+        });
+    }
+}

--- a/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/S3RestoreSpec.java
+++ b/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/S3RestoreSpec.java
@@ -1,0 +1,80 @@
+package com.tradeshift.reaktive.backup;
+
+import static org.forgerock.cuppa.Cuppa.beforeEach;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+import com.tradeshift.reaktive.protobuf.Query;
+import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
+import com.typesafe.config.ConfigFactory;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.stream.javadsl.Source;
+import akka.testkit.JavaTestKit;
+import javaslang.collection.Vector;
+
+@RunWith(CuppaRunner.class)
+public class S3RestoreSpec extends SharedActorSystemSpec {
+    public S3RestoreSpec() {
+        super(ConfigFactory.parseString("ts-reaktive.backup.restore.update-accuracy = 1 millisecond"));
+    }
+    
+    private final S3 s3 = mock(S3.class);
+    private final JavaTestKit shardRegion = new JavaTestKit(system);
+    
+    private ActorRef actor() {
+        return system.actorOf(Props.create(S3Restore.class, () -> new S3Restore(s3, "MyEvent", shardRegion.getRef())));
+    }
+    
+    {
+        describe("The S3Restore actor", () -> {
+            beforeEach(() -> {
+                reset(s3);
+                when(s3.list("MyEvent")).thenReturn(Source.from(Vector.of(
+                    new S3Entry("prefix/MyEvent-from-2016_11_09_13_29_28_030", Instant.now(), 100),
+                    new S3Entry("prefix/MyEvent-from-2016_11_09_13_31_11_259", Instant.now(), 100))));
+                when(s3.loadEvents("MyEvent-from-2016_11_09_13_29_28_030")).thenReturn(Source.from(Vector.of(eventEnvelope(1478698168030l, 0), eventEnvelope(1478698168031l, 1))));
+                when(s3.loadEvents("MyEvent-from-2016_11_09_13_31_11_259")).thenReturn(Source.from(Vector.of(eventEnvelope(1478698271259l, 2), eventEnvelope(1478698271260l, 3))));
+            });
+            
+            it("should send event envelopes to the shard region for all events in order, and then stop. When resumed, do so at a proper offset.", () -> {
+                ActorRef actor = actor();
+                
+                shardRegion.expectMsgEquals(eventEnvelope(1478698168030l,0));
+                shardRegion.reply(1478698168030l);
+                shardRegion.expectMsgEquals(eventEnvelope(1478698168031l,1));
+                shardRegion.reply(1478698168031l);
+                shardRegion.expectMsgEquals(eventEnvelope(1478698271259l,2));
+                shardRegion.reply(1478698271259l);
+                shardRegion.expectMsgEquals(eventEnvelope(1478698271260l,3));
+                shardRegion.reply(1478698271260l);
+                
+                JavaTestKit probe = new JavaTestKit(system);
+                probe.watch(actor);
+                probe.expectTerminated(actor);
+                
+                actor = actor();
+                // Expecting to resume at the last S3 entry, since the actor doesn't have a way of knowing whether it had been completed (only lastOffset is saved).
+                shardRegion.expectMsgEquals(eventEnvelope(1478698271259l,2));
+                shardRegion.reply(2l);
+            });
+        });
+    }
+
+    private com.tradeshift.reaktive.protobuf.Query.EventEnvelope eventEnvelope(long seqnr, long offset) {
+        return Query.EventEnvelope.newBuilder()
+            .setPersistenceId("pid")
+            .setSequenceNr(seqnr)
+            .setOffset(offset)
+            .build();
+    }
+}

--- a/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/S3Spec.java
+++ b/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/S3Spec.java
@@ -1,0 +1,43 @@
+package com.tradeshift.reaktive.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+import com.tradeshift.reaktive.backup.S3.S3ListResponse;
+import com.tradeshift.reaktive.marshal.stream.AaltoReader;
+import com.tradeshift.reaktive.marshal.stream.ProtocolReader;
+import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
+
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.StreamConverters;
+
+@RunWith(CuppaRunner.class)
+public class S3Spec extends SharedActorSystemSpec {
+    {
+        describe("S3ListResponse", () -> {
+            it("should be parseable from a real S3 list response", () -> {
+                List<S3ListResponse> list = StreamConverters.fromInputStream(() -> getClass().getResourceAsStream("listresponse.xml"))
+                    .via(AaltoReader.instance)
+                    .via(ProtocolReader.of(S3ListResponse.proto))
+                    .runWith(Sink.seq(), materializer)
+                    .toCompletableFuture()
+                    .get(1, TimeUnit.SECONDS);
+                
+                assertThat(list).hasSize(1);
+                assertThat(list.get(0).getNextContinuationToken().isDefined()).isFalse();
+                assertThat(list.get(0).getEntries()).hasSize(1);
+                assertThat(list.get(0).getEntries().head().getKey()).isEqualTo("S3BackupIntegrationSpec/1478683083999/MyEvent-from-19700101000000003");
+                assertThat(list.get(0).getEntries().head().getSize()).isEqualTo(296l);
+                assertThat(list.get(0).getEntries().head().getLastModified()).isEqualTo(Instant.parse("2016-11-09T09:18:09.001Z"));
+            });
+        });
+    }
+}

--- a/ts-reaktive-backup/src/test/resources/com/tradeshift/reaktive/backup/listresponse.xml
+++ b/ts-reaktive-backup/src/test/resources/com/tradeshift/reaktive/backup/listresponse.xml
@@ -1,0 +1,14 @@
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>bucketname</Name>
+  <Prefix>S3BackupIntegrationSpec/1478683083999/MyEvent</Prefix>
+  <KeyCount>1</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>S3BackupIntegrationSpec/1478683083999/MyEvent-from-19700101000000003</Key>
+    <LastModified>2016-11-09T09:18:09.001Z</LastModified>
+    <ETag>&quot;55f1e0c51016e172c49cbeb4b703ec01-1&quot;</ETag>
+    <Size>296</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Contents>
+</ListBucketResult>

--- a/ts-reaktive-backup/src/test/resources/log4j.xml
+++ b/ts-reaktive-backup/src/test/resources/log4j.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration>
+  <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out" />
+    <param name="Threshold" value="DEBUG" />
+    <layout class="org.apache.log4j.EnhancedPatternLayout">
+      <param name="ConversionPattern" value="%d{ABSOLUTE} %-5p [%c{1.}] %X{akkaSource} - %m%n" />
+    </layout>
+  </appender>
+  
+  <logger name="org.apache.cassandra"><level value="WARN" /></logger>
+  <logger name="com.datastax.driver"><level value="WARN" /></logger>
+  <logger name="io.netty"><level value="WARN" /></logger>
+  <logger name="Sigar"><level value="WARN"/></logger>
+  <logger name="org.apache.http"><level value="WARN"/></logger>
+  <logger name="org.mortbay"><level value="WARN"/></logger>
+  <logger name="akka"><level value="DEBUG"/></logger>
+  <logger name="akka.io"><level value="INFO"/></logger>
+  <logger name="akka.cluster.sharding"><level value="WARN"/></logger>
+  <logger name="akka.persistence.cassandra.query.EventsByTagPublisher"><level value="INFO"/></logger>
+  <logger name="com.tradeshift.reaktive.marshal"><level value="WARN"/></logger>
+  <logger name="com.tradeshift.reaktive.xml"><level value="WARN"/></logger>
+  
+  <!-- These are to get rid of the "Column family ID mismatch" errors during test startup -->
+  <logger name="org.apache.cassandra.service.CassandraDaemon"><level value="FATAL"/></logger>
+  <logger name="org.apache.cassandra.transport.Message"><level value="FATAL"/></logger>
+  <logger name="org.apache.cassandra.transport.Message"><level value="FATAL"/></logger>
+  <logger name="org.apache.cassandra.transport.messages.ErrorMessage"><level value="FATAL"/></logger>
+  
+  <root>
+    <priority value="DEBUG" />
+    <appender-ref ref="CONSOLE" />
+  </root>
+</log4j:configuration>

--- a/ts-reaktive-marshal/src/main/java/com/tradeshift/reaktive/marshal/StringMarshallable.java
+++ b/ts-reaktive-marshal/src/main/java/com/tradeshift/reaktive/marshal/StringMarshallable.java
@@ -2,6 +2,7 @@ package com.tradeshift.reaktive.marshal;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -49,7 +50,7 @@ public abstract class StringMarshallable<T> {
         @Override
         public String toString() {
             return "long";
-        }        
+        }
     };
     
     /** Java Integer converter. For JSON, please prefer to use {@link JSONProtocol.integerValue} since it maps to JSON number instead of string. */
@@ -67,7 +68,7 @@ public abstract class StringMarshallable<T> {
         @Override
         public String toString() {
             return "integer";
-        }        
+        }
     };
     
     /** Java BigDecimal converter. For JSON, please prefer to use {@link JSONProtocol.longValue} since it maps to JSON number instead of string. */
@@ -85,7 +86,7 @@ public abstract class StringMarshallable<T> {
         @Override
         public String toString() {
             return "big decimal";
-        }        
+        }
     };
     
     /** Java BigInteger converter. For JSON, please prefer to use {@link JSONProtocol.longValue} since it maps to JSON number instead of string. */
@@ -103,7 +104,7 @@ public abstract class StringMarshallable<T> {
         @Override
         public String toString() {
             return "big integer";
-        }        
+        }
     };
     
     /** Java UUID converter */
@@ -121,7 +122,27 @@ public abstract class StringMarshallable<T> {
         @Override
         public String toString() {
             return "uuid";
-        }        
+        }
+    };
+    
+    /**
+     * (un)marshals an Instant using ISO 8601 ( "2014-10-23T00:35:14.800Z" )
+     */
+    public static final StringMarshallable<Instant> INSTANT = new StringMarshallable<Instant>() {
+        @Override
+        public Try<Instant> tryRead(String value) {
+            return Try.of(() -> Instant.parse(value)).recover(prefixMessage("Expecting an ISO 8601 date"));
+        }
+
+        @Override
+        public String write(Instant value) {
+            return value.toString(); // formats as ISO 8601
+        }
+        
+        @Override
+        public String toString() {
+            return "ISO 8601 date";
+        }
     };
     
     private static <T> Function<Throwable,T> prefixMessage(String msg) {


### PR DESCRIPTION
The plan is as follows:
- `S3Backup` continuously reads event stream, batches it up, and writes keys into S3. Also continuously updates the "last written" offset in S3.
- `S3Restore` will list the bucket, (amazon sort it lexographically, so we'll make sure that's in event starting order), and then play back those events into a running instance of `PersistentActorSharding`.

This approach will save all event ordering and information, but lose the cassandra-intenals of when events were written (just like in multi-datacenter replication). That shouldn't be a problem, since proper events would have a real user business timestamp as well, anyways.

Possible alternative, future implementation: `S3Backup` reads events over HTTPS from an `EventRoute`, `S3Restore` plays back events over Websocket to a `WebSocketDataCenterServer`.
- Advantage: No binary deps on the concrete system being backed up / restored
- Disadvantage: When backup server fails, a new backup server has to be manually started

@alar17 @andrerigon what do you think?
