### PR TITLE
Upgrade to akka-persistence-cassandra:0.29 and cassandra-all:3.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val commonSettings = projectSettings ++ Seq(
       "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-jackson" % akkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % "test",
-      "com.typesafe.akka" %% "akka-persistence-cassandra" % "0.24",
+      "com.typesafe.akka" %% "akka-persistence-cassandra" % "0.29",
       "com.readytalk" % "metrics3-statsd" % "4.1.0", // to log cassandra (codahale / dropwizard) metrics into statsd
       "io.kamon" %% "kamon-core" % kamonVersion,
       "io.kamon" %% "kamon-akka-2.4" % kamonVersion,

--- a/ts-reaktive-actors/build.sbt
+++ b/ts-reaktive-actors/build.sbt
@@ -16,7 +16,7 @@ parallelExecution in Test := false
 // library dependencies. (organization name) % (project name) % (version) % (scope)
 libraryDependencies ++= {
   Seq(
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4",  
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4",
     "com.google.protobuf" % "protobuf-java" % "2.6.1",
     "junit" % "junit" % "4.11" % "test",
     "org.assertj" % "assertj-core" % "3.2.0" % "test",
@@ -26,7 +26,7 @@ libraryDependencies ++= {
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",
-    "org.apache.cassandra" % "cassandra-all" % "3.0.3" % "test" exclude("ch.qos.logback", "logback-classic"),
+    "org.apache.cassandra" % "cassandra-all" % "3.9" % "test" exclude("ch.qos.logback", "logback-classic"),
     "com.github.tomakehurst" % "wiremock" % "1.58" % "test"
   )
 }

--- a/ts-reaktive-backup/build.sbt
+++ b/ts-reaktive-backup/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= {
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",
-    "org.apache.cassandra" % "cassandra-all" % "3.0.3" % "test" exclude("ch.qos.logback", "logback-classic"),
+    "org.apache.cassandra" % "cassandra-all" % "3.9" % "test" exclude("ch.qos.logback", "logback-classic"),
     "com.github.tomakehurst" % "wiremock" % "1.58" % "test"
   )
 }

--- a/ts-reaktive-cassandra/build.sbt
+++ b/ts-reaktive-cassandra/build.sbt
@@ -16,9 +16,9 @@ parallelExecution in Test := false
 // library dependencies. (organization name) % (project name) % (version) % (scope)
 libraryDependencies ++= {
   Seq(
-    "com.google.guava" % "guava" % "18.0",  
+    "com.google.guava" % "guava" % "18.0",
     "com.readytalk" % "metrics3-statsd" % "4.1.0", // to log cassandra (codahale / dropwizard) metrics into statsd
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4",  
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4",
     "com.google.protobuf" % "protobuf-java" % "2.6.1",
     "junit" % "junit" % "4.11" % "test",
     "org.assertj" % "assertj-core" % "3.2.0" % "test",
@@ -28,7 +28,7 @@ libraryDependencies ++= {
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",
-    "org.apache.cassandra" % "cassandra-all" % "3.0.3" % "test" exclude("ch.qos.logback", "logback-classic"),
+    "org.apache.cassandra" % "cassandra-all" % "3.9" % "test" exclude("ch.qos.logback", "logback-classic"),
     "com.github.tomakehurst" % "wiremock" % "1.58" % "test"
   )
 }

--- a/ts-reaktive-cassandra/src/test/resources/log4j.xml
+++ b/ts-reaktive-cassandra/src/test/resources/log4j.xml
@@ -12,7 +12,6 @@
   <logger name="org.apache.cassandra"><level value="WARN" /></logger>
   <logger name="com.datastax.driver"><level value="WARN" /></logger>
   <logger name="io.netty"><level value="WARN" /></logger>
-  <logger name="com.tradeshift.documentcore.kamon"><level value="WARN" /></logger>
   <logger name="Sigar"><level value="WARN"/></logger>
   <logger name="org.apache.http"><level value="WARN"/></logger>
   <logger name="org.mortbay"><level value="WARN"/></logger>

--- a/ts-reaktive-marshal-akka/src/test/resources/test.xml
+++ b/ts-reaktive-marshal-akka/src/test/resources/test.xml
@@ -11,7 +11,6 @@
   <logger name="org.apache.cassandra"><level value="WARN" /></logger>
   <logger name="com.datastax.driver"><level value="WARN" /></logger>
   <logger name="io.netty"><level value="WARN" /></logger>
-  <logger name="com.tradeshift.documentcore.kamon"><level value="WARN" /></logger>
   <logger name="Sigar"><level value="WARN"/></logger>
   <logger name="org.apache.http"><level value="WARN"/></logger>
   <logger name="org.mortbay"><level value="WARN"/></logger>

--- a/ts-reaktive-replication/build.sbt
+++ b/ts-reaktive-replication/build.sbt
@@ -20,7 +20,7 @@ PB.includePaths in PB.protobufConfig += file("ts-reaktive-actors/src/main/protob
 libraryDependencies ++= {
   Seq(
     "com.readytalk" % "metrics3-statsd" % "4.1.0", // to log cassandra (codahale / dropwizard) metrics into statsd
-    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4",  
+    "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4",
     "com.google.protobuf" % "protobuf-java" % "2.6.1",
     "junit" % "junit" % "4.11" % "test",
     "org.assertj" % "assertj-core" % "3.2.0" % "test",
@@ -30,7 +30,7 @@ libraryDependencies ++= {
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",
-    "org.apache.cassandra" % "cassandra-all" % "3.0.3" % "test" exclude("ch.qos.logback", "logback-classic"),
+    "org.apache.cassandra" % "cassandra-all" % "3.9" % "test" exclude("ch.qos.logback", "logback-classic"),
     "com.github.tomakehurst" % "wiremock" % "1.58" % "test"
   )
 }

--- a/ts-reaktive-ssl/build.sbt
+++ b/ts-reaktive-ssl/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= {
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",
-    "org.apache.cassandra" % "cassandra-all" % "3.0.3" % "test" exclude("ch.qos.logback", "logback-classic"),
+    "org.apache.cassandra" % "cassandra-all" % "3.9" % "test" exclude("ch.qos.logback", "logback-classic"),
     "com.github.tomakehurst" % "wiremock" % "1.58" % "test"
   )
 }


### PR DESCRIPTION
Upgrading `akka-persistence-cassandra` and `cassandra-all` dependencies.
New version is more reliable because uses new `cassandra-driver-core` and few issues were fixed. Minimum required version of `cassandra-all` for `akka-persistence-cassandra` is 3.8.
Even if there are versions up to 3.11, lowest dependency that doesn't fail with log4j and logback issues for us is 3.9.
Some details:
- [explicit logback in cassandra-all-3.10](https://github.com/apache/cassandra/blob/cassandra-3.10/src/java/org/apache/cassandra/cql3/functions/ThreadAwareSecurityManager.java)
- [no explicit logback in cassandra-all-3.9](https://github.com/apache/cassandra/blob/cassandra-3.9/src/java/org/apache/cassandra/cql3/functions/ThreadAwareSecurityManager.java)
- [minimum version of cassandra-all that doesn't have `cdc_raw_directory` property](https://github.com/TimMoore/lagom/blob/ee1dc6bad38a8146a1b131b0654d5a232cbeaa0f/persistence-cassandra/core/src/main/resources/lagom-test-embedded-cassandra.yaml)
- [change log for java-driver `3.2`](https://docs.datastax.com/en/developer/java-driver/3.2/changelog)

@jypma, @alar17 please review
