### PR TITLE
Upgrade to akka-persistence-inmemory 2.4.18.1

### DIFF
--- a/ts-reaktive-actors/build.sbt
+++ b/ts-reaktive-actors/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= {
     "org.assertj" % "assertj-core" % "3.2.0" % "test",
     "org.mockito" % "mockito-core" % "1.10.19" % "test",
     "info.solidsoft.mockito" % "mockito-java8" % "0.3.0" % "test",
-    "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.2.0" % "test",
+    "com.github.dnvriend" %% "akka-persistence-inmemory" % "2.4.18.1" % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",

--- a/ts-reaktive-backup/build.sbt
+++ b/ts-reaktive-backup/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= {
     "org.assertj" % "assertj-core" % "3.2.0" % "test",
     "org.mockito" % "mockito-core" % "1.10.19" % "test",
     "info.solidsoft.mockito" % "mockito-java8" % "0.3.0" % "test",
-    "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.3.0" % "test",
+    "com.github.dnvriend" %% "akka-persistence-inmemory" % "2.4.18.1" % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",

--- a/ts-reaktive-cassandra/build.sbt
+++ b/ts-reaktive-cassandra/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= {
     "org.assertj" % "assertj-core" % "3.2.0" % "test",
     "org.mockito" % "mockito-core" % "1.10.19" % "test",
     "info.solidsoft.mockito" % "mockito-java8" % "0.3.0" % "test",
-    "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.2.0" % "test",
+    "com.github.dnvriend" %% "akka-persistence-inmemory" % "2.4.18.1" % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",

--- a/ts-reaktive-replication/build.sbt
+++ b/ts-reaktive-replication/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= {
     "org.assertj" % "assertj-core" % "3.2.0" % "test",
     "org.mockito" % "mockito-core" % "1.10.19" % "test",
     "info.solidsoft.mockito" % "mockito-java8" % "0.3.0" % "test",
-    "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.3.0" % "test",
+    "com.github.dnvriend" %% "akka-persistence-inmemory" % "2.4.18.1" % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",

--- a/ts-reaktive-ssl/build.sbt
+++ b/ts-reaktive-ssl/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= {
     "org.assertj" % "assertj-core" % "3.2.0" % "test",
     "org.mockito" % "mockito-core" % "1.10.19" % "test",
     "info.solidsoft.mockito" % "mockito-java8" % "0.3.0" % "test",
-    "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.2.0" % "test",
+    "com.github.dnvriend" %% "akka-persistence-inmemory" % "2.4.18.1" % "test",
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",

--- a/ts-reaktive-testkit/build.sbt
+++ b/ts-reaktive-testkit/build.sbt
@@ -20,6 +20,6 @@ libraryDependencies ++= {
     "com.novocode" % "junit-interface" % "0.11" % "test",
     "org.forgerock.cuppa" % "cuppa" % "1.1.0" % "test",
     "org.forgerock.cuppa" % "cuppa-junit" % "1.1.0" % "test",
-    "com.github.dnvriend" %% "akka-persistence-inmemory" % "1.3.5"
+    "com.github.dnvriend" %% "akka-persistence-inmemory" % "2.4.18.1"
   )
 }


### PR DESCRIPTION
Related to https://github.com/Tradeshift/ts-reaktive/issues/64
This version supports scala 2.12.
The current dependency versions do not.
I'll raise an issue for "com.bluelabs" %% "s3-stream" % "0.0.3" because
that does not support scala 2.12 either and this code is no longer maintained
(is now part of alpakka).