### PR TITLE
Upgrade to akka to 2.5.4, and related libraries.

### DIFF
--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/actors/AbstractStatefulPersistentActorSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/actors/AbstractStatefulPersistentActorSpec.java
@@ -17,7 +17,7 @@ import akka.Done;
 import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.japi.pf.PFBuilder;
-import akka.testkit.JavaTestKit;
+import akka.testkit.javadsl.TestKit;
 import javaslang.collection.Seq;
 import javaslang.collection.Vector;
 import scala.PartialFunction;
@@ -122,7 +122,7 @@ public class AbstractStatefulPersistentActorSpec extends SharedActorSystemSpec {
         describe("AbstractStatefulPersistentActor.applyCommandAsync", () -> {
             it("should process several async commands concurrently, until their handlers are resolved", () -> {
                 ActorRef actor = system.actorOf(Props.create(MyActor.class));
-                JavaTestKit probe = new JavaTestKit(system);
+                TestKit probe = new TestKit(system);
                 // Send a synchronous message first, to ensure persistence has initialized successfully and doesn't affect timing.
                 probe.send(actor, "1:sync");
                 probe.expectMsgEquals(Done.getInstance());

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/akka/rest/EventRouteIntegrationSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/akka/rest/EventRouteIntegrationSpec.java
@@ -18,16 +18,16 @@ import com.tradeshift.reaktive.protobuf.Query;
 import com.tradeshift.reaktive.testkit.HttpIntegrationSpec;
 
 import akka.http.javadsl.model.StatusCodes;
-import akka.persistence.query.EventEnvelope2;
+import akka.persistence.query.EventEnvelope;
 import akka.persistence.query.TimeBasedUUID;
-import akka.persistence.query.javadsl.EventsByTagQuery2;
+import akka.persistence.query.javadsl.EventsByTagQuery;
 import akka.stream.StreamTcpException;
 import akka.stream.javadsl.Source;
 
 @RunWith(CuppaRunner.class)
 public class EventRouteIntegrationSpec extends HttpIntegrationSpec {
     
-    private EventRoute testEventRoute(EventsByTagQuery2 journal) {
+    private EventRoute testEventRoute(EventsByTagQuery journal) {
         EventEnvelopeSerializer serializer = mock(EventEnvelopeSerializer.class);
         when(serializer.toProtobuf(any())).thenReturn(Query.EventEnvelope.newBuilder().build());
         return new EventRoute(materializer, journal, serializer, "testEvent");
@@ -50,7 +50,7 @@ public class EventRouteIntegrationSpec extends HttpIntegrationSpec {
         when("the underlying source completes with error after events have been sent out", () -> {
             EventRoute eventRoute = testEventRoute((tag, idx) -> {
                 return Source.repeat(
-                    EventEnvelope2.apply(new TimeBasedUUID(UUIDs.startOf(1)), "doc_bc779420-beac-4636-b747-ea0a587d4f8b", 1, "hello")
+                    EventEnvelope.apply(new TimeBasedUUID(UUIDs.startOf(1)), "doc_bc779420-beac-4636-b747-ea0a587d4f8b", 1, "hello")
                 ).concat(
                     Source.failed(new RuntimeException("simulated failure mid-stream"))
                 );

--- a/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3.java
+++ b/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3.java
@@ -19,7 +19,7 @@ import akka.Done;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.japi.pf.PFBuilder;
-import akka.persistence.query.EventEnvelope2;
+import akka.persistence.query.EventEnvelope;
 import akka.persistence.query.TimeBasedUUID;
 import akka.stream.Materializer;
 import akka.stream.alpakka.s3.javadsl.ListBucketResultContents;
@@ -87,7 +87,7 @@ public class S3 {
      * Stores the given buffered events into S3, under a key that includes the tag and the offset of the first event.
      * @param tag Persistence tag that the events were for
      */
-    public CompletionStage<Done> store(String tag, Seq<EventEnvelope2> events) {
+    public CompletionStage<Done> store(String tag, Seq<EventEnvelope> events) {
         String key = tag + SEPARATOR + FMT.format(Instant.ofEpochMilli(UUIDs.unixTimestamp(TimeBasedUUID.class.cast(events.get(0).offset()).value())));
         return Source.from(events)
               .map(e -> {

--- a/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Backup.java
+++ b/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Backup.java
@@ -21,14 +21,12 @@ import akka.japi.pf.ReceiveBuilder;
 import akka.pattern.Backoff;
 import akka.pattern.BackoffSupervisor;
 import akka.persistence.query.NoOffset;
-import akka.persistence.query.javadsl.EventsByTagQuery2;
+import akka.persistence.query.javadsl.EventsByTagQuery;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import javaslang.collection.Vector;
-import scala.PartialFunction;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
-import scala.runtime.BoxedUnit;
 
 /**
  * Makes a continuous backup of events onto an S3 bucket, grouping events into keys of predefined batch sizes.
@@ -45,7 +43,7 @@ public class S3Backup extends AbstractActor {
      * @param tag Tag to pass to the above query
      * @param s3 Service interface to communicate with S3
      */
-    public static void start(ActorSystem system, EventsByTagQuery2 query, String tag, S3 s3) {
+    public static void start(ActorSystem system, EventsByTagQuery query, String tag, S3 s3) {
         system.actorOf(ClusterSingletonManager.props(
             BackoffSupervisor.props(
                 Backoff.onFailure(
@@ -62,13 +60,13 @@ public class S3Backup extends AbstractActor {
     private static final Logger log = LoggerFactory.getLogger(S3Backup.class);
     
     private final Materializer materializer = SharedActorMaterializer.get(context().system());
-    private final EventsByTagQuery2 query;
+    private final EventsByTagQuery query;
     private final String tag;
     private final S3 s3;
     private final int eventChunkSize;
     private final FiniteDuration eventChunkDuration;
     
-    public S3Backup(EventsByTagQuery2 query, String tag, S3 s3) {
+    public S3Backup(EventsByTagQuery query, String tag, S3 s3) {
         this.query = query;
         this.tag = tag;
         this.s3 = s3;
@@ -78,15 +76,18 @@ public class S3Backup extends AbstractActor {
         eventChunkDuration = FiniteDuration.create(backupCfg.getDuration("event-chunk-max-duration", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
         
         pipe(s3.loadOffset(), context().dispatcher()).to(self());
-        
-        receive(ReceiveBuilder
-            .match(Long.class, offset -> {
-                context().become(startBackup(offset));
-            })
-            .build());
     }
 
-    private PartialFunction<Object, BoxedUnit> startBackup(long offset) {
+    @Override
+    public Receive createReceive() {
+    	return ReceiveBuilder.create()
+            .match(Long.class, offset -> {
+                getContext().become(startBackup(offset));
+            })
+            .build();
+    }
+    
+    private Receive startBackup(long offset) {
         query
             .eventsByTag(tag, NoOffset.getInstance())
             // create backups of max [N] elements, or at least every [T] on activity
@@ -96,7 +97,7 @@ public class S3Backup extends AbstractActor {
             .mapAsync(4, list -> s3.store(tag, Vector.ofAll(list)).thenApply(done -> list.get(list.size() - 1).offset()))
             .runWith(Sink.actorRefWithAck(self(), "init", "ack", "done", Failure::new), materializer);
         
-        return ReceiveBuilder
+        return ReceiveBuilder.create()
             .matchEquals("init", msg -> sender().tell("ack", self()))
             .match(Long.class, l -> pipe(s3.saveOffset(l).thenApply(done -> "ack"), context().dispatcher()).to(sender()))
             .match(Failure.class, msg -> {

--- a/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Restore.java
+++ b/ts-reaktive-backup/src/main/java/com/tradeshift/reaktive/backup/S3Restore.java
@@ -1,7 +1,7 @@
 package com.tradeshift.reaktive.backup;
 
-import static com.tradeshift.reaktive.backup.DropUntilNext.dropUntilNext;
 import static akka.pattern.PatternsCS.ask;
+import static com.tradeshift.reaktive.backup.DropUntilNext.dropUntilNext;
 
 import java.util.concurrent.TimeUnit;
 
@@ -20,9 +20,7 @@ import akka.persistence.RecoveryCompleted;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.util.Timeout;
-import scala.PartialFunction;
 import scala.concurrent.duration.FiniteDuration;
-import scala.runtime.BoxedUnit;
 
 /**
  * Restores from an S3 bucket that S3Backup has written to.
@@ -64,8 +62,8 @@ public class S3Restore extends AbstractPersistentActor {
     }
     
     @Override
-    public PartialFunction<Object, BoxedUnit> receiveCommand() {
-        return ReceiveBuilder
+    public Receive createReceive() {
+        return ReceiveBuilder.create()
             .matchEquals("init", msg -> sender().tell("ack", self()))
             .match(Long.class, (Long o) -> {
                 log.debug("Persisting {}", o);
@@ -89,8 +87,8 @@ public class S3Restore extends AbstractPersistentActor {
     }
 
     @Override
-    public PartialFunction<Object, BoxedUnit> receiveRecover() {
-        return ReceiveBuilder
+    public Receive createReceiveRecover() {
+        return ReceiveBuilder.create()
             .match(Long.class, o -> offset = o)
             .match(RecoveryCompleted.class, msg -> startRestore())
             .build();

--- a/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/S3RestoreSpec.java
+++ b/ts-reaktive-backup/src/test/java/com/tradeshift/reaktive/backup/S3RestoreSpec.java
@@ -20,7 +20,7 @@ import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.stream.alpakka.s3.javadsl.ListBucketResultContents;
 import akka.stream.javadsl.Source;
-import akka.testkit.JavaTestKit;
+import akka.testkit.javadsl.TestKit;
 import javaslang.collection.Vector;
 
 @RunWith(CuppaRunner.class)
@@ -30,7 +30,7 @@ public class S3RestoreSpec extends SharedActorSystemSpec {
     }
     
     private final S3 s3 = mock(S3.class);
-    private final JavaTestKit shardRegion = new JavaTestKit(system);
+    private final TestKit shardRegion = new TestKit(system);
     
     private ActorRef actor() {
         return system.actorOf(Props.create(S3Restore.class, () -> new S3Restore(s3, "MyEvent", shardRegion.getRef())));
@@ -59,7 +59,7 @@ public class S3RestoreSpec extends SharedActorSystemSpec {
                 shardRegion.expectMsgEquals(eventEnvelope(1478698271260l,3));
                 shardRegion.reply(1478698271260l);
                 
-                JavaTestKit probe = new JavaTestKit(system);
+                TestKit probe = new TestKit(system);
                 probe.watch(actor);
                 probe.expectTerminated(actor);
                 

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/DataCenter.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/DataCenter.java
@@ -1,6 +1,6 @@
 package com.tradeshift.reaktive.replication;
 
-import akka.persistence.query.EventEnvelope2;
+import akka.persistence.query.EventEnvelope;
 import akka.stream.javadsl.Flow;
 
 /**
@@ -16,5 +16,5 @@ public interface DataCenter {
      * Returns a flow that can be used to upload events to this data center. Its output will periodically
      * emit the offset of events that have been successfully uploaded.
      */
-    Flow<EventEnvelope2,Long,?> uploadFlow();
+    Flow<EventEnvelope,Long,?> uploadFlow();
 }

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/Replication.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/Replication.java
@@ -26,7 +26,7 @@ import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.persistence.query.PersistenceQuery;
 import akka.persistence.query.javadsl.CurrentEventsByPersistenceIdQuery;
-import akka.persistence.query.javadsl.EventsByTagQuery2;
+import akka.persistence.query.javadsl.EventsByTagQuery;
 import akka.persistence.query.javadsl.ReadJournal;
 import akka.stream.ActorMaterializer;
 import javaslang.collection.Seq;
@@ -114,7 +114,7 @@ public class Replication implements Extension {
             ReadJournal journal = PersistenceQuery.get(system).getReadJournalFor(ReadJournal.class, config.getString("read-journal-plugin-id"));
             
             DataCenterForwarder.startAll(system, materializer, dataCenterRepository, visibilityRepo, eventType,
-                (EventsByTagQuery2)journal, (CurrentEventsByPersistenceIdQuery) journal);
+                (EventsByTagQuery)journal, (CurrentEventsByPersistenceIdQuery) journal);
             
             WebSocketDataCenterServer server = new WebSocketDataCenterServer(config.getConfig("server"), shardRegion);
             final int port = tagConfig.getInt("local-datacenter.port");

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/io/WebSocketDataCenterClient.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/io/WebSocketDataCenterClient.java
@@ -16,7 +16,7 @@ import akka.http.javadsl.model.ws.BinaryMessage;
 import akka.http.javadsl.model.ws.Message;
 import akka.http.javadsl.model.ws.WebSocketRequest;
 import akka.http.javadsl.settings.ClientConnectionSettings;
-import akka.persistence.query.EventEnvelope2;
+import akka.persistence.query.EventEnvelope;
 import akka.stream.javadsl.Flow;
 import akka.util.ByteString;
 
@@ -52,10 +52,10 @@ public class WebSocketDataCenterClient implements DataCenter {
     }
     
     @Override
-    public Flow<EventEnvelope2,Long,?> uploadFlow() {
+    public Flow<EventEnvelope,Long,?> uploadFlow() {
         ClientConnectionSettings settings = ClientConnectionSettings.create(system.settings().config());
         
-        return Flow.<EventEnvelope2>create()
+        return Flow.<EventEnvelope>create()
             .map(e -> (Message) BinaryMessage.create(serialize(e)))
             .via(Http.get(system).webSocketClientFlow(WebSocketRequest.create(uri), connectionContext, Optional.empty(), settings, system.log()))
             .map(msg -> {
@@ -70,7 +70,7 @@ public class WebSocketDataCenterClient implements DataCenter {
             .filter(l -> l > 0);
     }
 
-    protected ByteString serialize(EventEnvelope2 e) {
+    protected ByteString serialize(EventEnvelope e) {
         return ByteString.fromArray(serializer.toProtobuf(e).toByteArray());
     }
 }

--- a/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/FakeRemoteTestActor.java
+++ b/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/FakeRemoteTestActor.java
@@ -4,8 +4,6 @@ import com.tradeshift.reaktive.replication.TestData.TestEvent;
 
 import akka.japi.pf.ReceiveBuilder;
 import akka.persistence.AbstractPersistentActor;
-import scala.PartialFunction;
-import scala.runtime.BoxedUnit;
 
 /**
  * Actor which just emits a single event into its journal and then exits. We do this to simulate a remote journal having been replicated to here.
@@ -20,8 +18,8 @@ public class FakeRemoteTestActor extends AbstractPersistentActor {
     }
 
     @Override
-    public PartialFunction<Object, BoxedUnit> receiveCommand() {
-        return ReceiveBuilder
+    public Receive createReceive() {
+        return ReceiveBuilder.create()
             .matchEquals("init", msg -> {
                 persist(TestEvent.newBuilder().setMsg(event).build(), e -> {
                     context().stop(self());
@@ -31,8 +29,8 @@ public class FakeRemoteTestActor extends AbstractPersistentActor {
     }
 
     @Override
-    public PartialFunction<Object, BoxedUnit> receiveRecover() {
-        return ReceiveBuilder
+    public Receive createReceiveRecover() {
+        return ReceiveBuilder.create()
             .matchAny(msg -> {})
             .build();
     }

--- a/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/ReplicationIntegrationSpec.java
+++ b/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/ReplicationIntegrationSpec.java
@@ -4,7 +4,6 @@ import static akka.pattern.PatternsCS.ask;
 import static com.tradeshift.reaktive.protobuf.UUIDs.toProtobuf;
 import static com.tradeshift.reaktive.testkit.Await.eventuallyDo;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.forgerock.cuppa.Cuppa.after;
 import static org.forgerock.cuppa.Cuppa.describe;
 import static org.forgerock.cuppa.Cuppa.it;
 
@@ -173,10 +172,6 @@ public class ReplicationIntegrationSpec {
                 assertThat(dc2.read(ids.get(1))).isEqualTo("moar");
             });
         });
-        
-        after(() -> {
-            CassandraLauncher.stop();
-        });        
     });
     
 }}

--- a/ts-reaktive-testkit/src/main/java/com/tradeshift/reaktive/testkit/AkkaPersistence.java
+++ b/ts-reaktive-testkit/src/main/java/com/tradeshift/reaktive/testkit/AkkaPersistence.java
@@ -1,17 +1,16 @@
 package com.tradeshift.reaktive.testkit;
 
+import static com.tradeshift.reaktive.testkit.Await.within;
+
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import static com.tradeshift.reaktive.testkit.Await.*;
 
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.japi.pf.ReceiveBuilder;
 import akka.persistence.AbstractPersistentActor;
 import akka.testkit.TestProbe;
-import scala.PartialFunction;
 import scala.concurrent.duration.FiniteDuration;
-import scala.runtime.BoxedUnit;
 
 public class AkkaPersistence {
     private final ActorSystem system;
@@ -35,8 +34,8 @@ public class AkkaPersistence {
     
     private static class AwaitPersistenceInit extends AbstractPersistentActor {
         @Override
-        public PartialFunction<Object, BoxedUnit> receiveCommand() {
-            return ReceiveBuilder.matchAny(msg -> {
+        public Receive createReceive() {
+            return ReceiveBuilder.create().matchAny(msg -> {
                 persist(msg, m -> {
                     sender().tell(msg, self());
                     context().stop(self());
@@ -45,8 +44,8 @@ public class AkkaPersistence {
         }
 
         @Override
-        public PartialFunction<Object, BoxedUnit> receiveRecover() {
-            return ReceiveBuilder.matchAny(msg -> {}).build();
+        public Receive createReceiveRecover() {
+            return ReceiveBuilder.create().matchAny(msg -> {}).build();
         }
 
         @Override


### PR DESCRIPTION
We now also postfix _2.12 and _2.11 for the Java artifacts, since they
can transiently depend on something that does bring in Scala.