### PR TITLE
Allow a "*" datacenter to indicate replication to everywhere

### DIFF
--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/DataCenterForwarder.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/DataCenterForwarder.java
@@ -216,7 +216,7 @@ public class DataCenterForwarder<E> extends AbstractActor {
                     return visibilityRepo.setMaster(e.persistenceId(), weAreMaster).thenApply(done -> Tuple.of(e, shouldMakeVisible));
                 } else {
                     return visibilityRepo.getVisibility(e.persistenceId()).thenApply(v -> {
-                        log.debug("visibility of {} is {}/{}", e, v.isMaster(), v.getDatacenters());
+                        log.debug("visibility of {} is {}", e, v);
                         return Tuple.of(e, v.isMaster() && !v.isVisibleTo(dataCenter));});
                 }
             })

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/EventClassifier.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/EventClassifier.java
@@ -11,6 +11,9 @@ public interface EventClassifier<E> {
      * persistence ID of the given event, after the event has been applied, or Seq.empty()
      * if the data centers should remain unchanged.
      * 
+     * In order to have an aggregate be replicated to ALL known datacenters, include "*" as a 
+     * data center name.
+     * 
      * This must be implemented as a pure function, relying only on the event itself. In other words,
      * the event must fully imply to which datacenters replication is to be done. This is to guarantee
      * full idempotency when replaying.

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/Visibility.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/Visibility.java
@@ -18,24 +18,26 @@ public class Visibility {
     
     /**
      * Creates a new Visibility.
-     * @param datacenters The data centers to which this persistenceId should be visible
-     * @param master Whether the current data center is the master. Only the master will replicate events to other data centers.
+     * @param datacenters The data centers to which this persistenceId should be visible.
+     *        If this includes "*" as an element, the persistenceId is to be visible to
+     *        ALL data centers.
+     * @param master Whether the current data center is the master for the persistenceId. 
+     *        Only the master will replicate events to other data centers.
      */
     public Visibility(Set<String> datacenters, boolean master) {
         this.datacenters = datacenters;
         this.master = master;
     }
 
-    public Set<String> getDatacenters() {
-        return datacenters;
-    }
-    
     public boolean isMaster() {
         return master;
     }
 
+    /**
+     * Returns whether the persistenceId should be replicated to the given data center.
+     */
     public boolean isVisibleTo(DataCenter dataCenter) {
-        return datacenters.contains(dataCenter.getName());
+        return datacenters.contains("*") || datacenters.contains(dataCenter.getName());
     }
 
     /**
@@ -43,5 +45,14 @@ public class Visibility {
      */
     public Visibility add(String dataCenter) {
         return new Visibility(datacenters.add(dataCenter), master);
+    }
+    
+    public Visibility withMaster(boolean master) {
+        return new Visibility(datacenters, master);
+    }
+
+    @Override
+    public String toString() {
+        return "[datacenters=" + datacenters + ", master=" + master + "]";
     }
 }

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/VisibilityRepository.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/VisibilityRepository.java
@@ -48,7 +48,7 @@ public class VisibilityRepository {
     }
 
     public CompletionStage<Boolean> isVisibleTo(DataCenter target, String persistenceId) {
-        return getVisibility(persistenceId).thenApply(v -> v.getDatacenters().contains(target.getName()));
+        return getVisibility(persistenceId).thenApply(v -> v.isVisibleTo(target));
     }
 
     /**

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/actors/ReplicatedActor.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/actors/ReplicatedActor.java
@@ -89,7 +89,8 @@ public abstract class ReplicatedActor<C,E,S extends AbstractState<E,S>> extends 
                 E event = createMigrationEvent();
                 if (!includesLocalDataCenter(event)) {
                     throw new IllegalStateException(
-                            "createMigrationEvent() returned an event that does NOT include the local data center");
+                            "createMigrationEvent() returned an event that does NOT include the local data center "
+                            + replication.getLocalDataCenterName() + ", but instead " + classifier().getDataCenterNames(event));
                 }
                 persistEvent(event, e -> {
                     getContext().become(master());
@@ -188,7 +189,7 @@ public abstract class ReplicatedActor<C,E,S extends AbstractState<E,S>> extends 
     protected void validateFirstEvent(E e) {
         if (!includesLocalDataCenter(e)) {
             throw new IllegalStateException("First-emitted event of a ReplicatedActor must yield local data center name (" +
-                replication.getLocalDataCenterName() + ") when given to EventClassifier, but instead got: " +
+                replication.getLocalDataCenterName() + ") as first element when given to EventClassifier, but instead got: " +
                 classifier().getDataCenterNames(e).mkString(", "));
         }
     }

--- a/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/ReplicationIntegrationSpec.java
+++ b/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/ReplicationIntegrationSpec.java
@@ -131,6 +131,17 @@ public class ReplicationIntegrationSpec {
             eventuallyDo(() -> {
                 assertThat(dc2.read(id1)).isEqualTo("moar");
             });
+            
+            // Should replicate to all datacenters if event classifier returns "*"
+            UUID id2 = UUID.fromString("95b2a8ba-3960-4bca-b803-c6aec238e99a");
+            dc1.write(id2, "dc:" + dc1.getName());
+            dc1.write(id2, "hello");
+            dc1.write(id2, "dc:*");
+            dc1.write(id2, "world");
+            
+            eventuallyDo(() -> {
+                assertThat(dc2.read(id2)).isEqualTo("world");
+            });
         });
         
         it("should replicate lots of events to another datacenter once the EventRepository indicates it", () -> {


### PR DESCRIPTION
Which will also automatically pick up new datacenters as they are added
(after a restart, of course)