### PR TITLE
Add an API rate limiting directive

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ val assertJ = "org.assertj" % "assertj-core" % "3.2.0"
 lazy val projectSettings = Seq(
   licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
   organization := "com.tradeshift",
-  version := "0.0.33",
+  version := "0.0.34-SNAPSHOT",
   scalaVersion := "2.12.3",
   crossScalaVersions := Seq("2.11.11", "2.12.3"),
   publishMavenStyle := true,
@@ -131,6 +131,7 @@ lazy val `ts-reaktive-testkit-assertj` = project
 
 lazy val `ts-reaktive-akka` = project
   .settings(commonSettings: _*)
+  .dependsOn(`ts-reaktive-testkit` % "test")
 
 lazy val `ts-reaktive-marshal` = project
   .settings(projectSettings: _*)

--- a/ts-reaktive-akka/src/main/java/com/tradeshift/reaktive/throttle/RateLimitExceededRejection.java
+++ b/ts-reaktive-akka/src/main/java/com/tradeshift/reaktive/throttle/RateLimitExceededRejection.java
@@ -1,0 +1,22 @@
+package com.tradeshift.reaktive.throttle;
+
+import static akka.http.javadsl.server.Directives.complete;
+
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.CustomRejection;
+import akka.http.javadsl.server.RejectionHandler;
+
+/**
+ * Rejection that indicates a rate limit has been exceeded.
+ */
+public class RateLimitExceededRejection implements CustomRejection {
+    public static final RateLimitExceededRejection instance = new RateLimitExceededRejection();
+    
+    public static RejectionHandler defaultHandler = RejectionHandler.newBuilder()
+        .handle(RateLimitExceededRejection.class, rejection ->
+            complete(StatusCodes.ENHANCE_YOUR_CALM, "API Rate Limit Exceeded for this user.")
+        )
+        .build();
+    
+    private RateLimitExceededRejection() {}
+}

--- a/ts-reaktive-akka/src/main/java/com/tradeshift/reaktive/throttle/ThrottleActor.java
+++ b/ts-reaktive-akka/src/main/java/com/tradeshift/reaktive/throttle/ThrottleActor.java
@@ -1,0 +1,74 @@
+package com.tradeshift.reaktive.throttle;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.actor.AbstractActor;
+import akka.actor.ReceiveTimeout;
+import akka.cluster.sharding.ShardRegion;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * A ThrottleActor handles the throtting decision for an individual user. One ThrottleActor is created
+ * for each user (each unique "key" passed to ThrottleDirective.throttle). They automatically passivate
+ * themselves once a user's request quota has been filled up again. 
+ */
+public class ThrottleActor extends AbstractActor {
+    private static final Logger log = LoggerFactory.getLogger(ThrottleActor.class);
+    
+    private final int tokensPerRefill;
+    private final Duration refill;
+    private final int maximumBurst;
+    
+    private int value;
+    private Instant lastUpdate;
+
+    public ThrottleActor(int tokensPerRefill, Duration refill, int maximumBurst) {
+        this.tokensPerRefill = tokensPerRefill;
+        this.refill = refill;
+        this.maximumBurst = maximumBurst;
+        this.value = maximumBurst;
+        this.lastUpdate = Instant.now();
+        
+        // We've reached maximumBurst for sure after not seeing any requests for this long:
+        Duration receiveTimeout = refill.multipliedBy((long) Math.ceil( (double)maximumBurst / tokensPerRefill));
+        context().setReceiveTimeout(FiniteDuration.fromNanos(receiveTimeout.toNanos()));
+    }
+
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+            .match(String.class, key -> handleRequest())
+            .match(ReceiveTimeout.class, msg -> passivate())
+            .match(Stop.class, msg -> context().stop(self()))
+            .build();
+    }
+
+    private void handleRequest() {
+        final Instant now = Instant.now();
+        final int refillCount = (int) Math.floor(Duration.between(lastUpdate, now).toMillis() / refill.toMillis());
+        
+        value = Math.min(maximumBurst, value + refillCount * tokensPerRefill);
+        // Only forward lastUpdate to the point where we've granted new elements
+        final Instant grantEnd = lastUpdate.plus(refill.multipliedBy(refillCount));
+        lastUpdate = now.isAfter(grantEnd) ? grantEnd : now;
+        
+        log.debug("Handling request for user {}, has {} tokens", self().path().name(), value);
+        final boolean granted = value > 0;
+        if (granted) {
+            value--;
+        }
+        sender().tell(granted, self());
+    }
+    
+    private void passivate() {
+        context().parent().tell(new ShardRegion.Passivate(Stop.instance), self());
+    }
+
+    private static final class Stop {
+        private static final Stop instance = new Stop();
+    }
+}

--- a/ts-reaktive-akka/src/main/java/com/tradeshift/reaktive/throttle/ThrottleDirective.java
+++ b/ts-reaktive-akka/src/main/java/com/tradeshift/reaktive/throttle/ThrottleDirective.java
@@ -1,0 +1,87 @@
+package com.tradeshift.reaktive.throttle;
+
+import static akka.http.javadsl.server.Directives.onSuccess;
+import static akka.http.javadsl.server.Directives.reject;
+import static akka.http.javadsl.server.Directives.handleRejections;
+import static akka.pattern.PatternsCS.ask;
+
+import java.util.Base64;
+import java.time.Duration;
+import java.util.function.Supplier;
+import java.nio.charset.StandardCharsets;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.cluster.sharding.ClusterSharding;
+import akka.cluster.sharding.ClusterShardingSettings;
+import akka.cluster.sharding.ShardRegion.MessageExtractor;
+import akka.http.javadsl.server.Route;
+
+/**
+ * Implements an API rate limiting directive for akka http that is cluster-aware.
+ */
+public class ThrottleDirective {
+    private final ActorRef shardRegion;
+
+    /**
+     * Returns a directive that can be used to throttle requests (API rate limiting). In an actual route, you have to invoke
+     * {@link #throttle(String, Route)} to perform the rate check. You'll pass an application-specific key that identifies
+     * the current user to that method, so that all users are limited individualing.
+     * 
+     * The throttling is cluster-aware, i.e. rate limits are applied across the whole akka cluster.
+     * 
+     * @param system Actor system to use (we use cluster sharding underneath to guarantee rate limiting across the cluster)
+     * @param tokensPerRefill Number of tokens to grant on every refill period. Making a request uses up one token, if available, and fails otherwise.
+     * @param refill Refill period. New tokens will be granted every period.
+     * @param maximumBurst Maximum number of tokens that can be "saved up" if no requests are made for multiple periods.
+     */
+    public ThrottleDirective(ActorSystem system, int tokensPerRefill, Duration refill, int maximumBurst) {
+        this.shardRegion = ClusterSharding.get(system).start("throttler-" + tokensPerRefill + "-" + refill.getSeconds() + "-" + maximumBurst,
+            Props.create(ThrottleActor.class, () -> new ThrottleActor(tokensPerRefill, refill, maximumBurst)),
+            ClusterShardingSettings.create(system), new MessageExtractor() {
+                @Override
+                public String entityId(Object message) {
+                    return Base64.getEncoder().encodeToString(message.toString().getBytes(StandardCharsets.UTF_8));
+                }
+
+                @Override
+                public Object entityMessage(Object message) {
+                    return message;
+                }
+
+                @Override
+                public String shardId(Object message) {
+                    return String.valueOf(message.toString().hashCode() % 256);
+                }
+            });
+    }
+
+    /**
+     * Runs the request through this directive's rate limiter under the given key, and rejects the request with
+     * a {@link RateLimitExceededRejection} if the rate limit is exceeded.
+     * 
+     * @param key User-specific key to do rate limiting against. Each key is counted separately.
+     * @param route Route to invoke if rate limit has not been exceeded.
+     */
+    public Route throttle(String key, Supplier<Route> route) {
+        return onSuccess(() -> ask(shardRegion, key, 60000), granted -> {
+            if (Boolean.class.cast(granted)) {
+                return route.get();
+            } else {
+                return reject(RateLimitExceededRejection.instance);
+            }
+        });
+    }
+    
+    /**
+     * Invokes {@link #throttle(String, Route)} wrapped in {@link RateLimitExceededRejection}'s default
+     * rejection handler (which fails the request with 420 Enhance Your Calm if rate limit is exceeded).
+     * 
+     * @param key User-specific key to do rate limiting against. Each key is counted separately.
+     * @param route Route to invoke if rate limit has not been exceeded.
+     */
+    public Route throttleSealed(String key, Supplier<Route> route) {
+        return handleRejections(RateLimitExceededRejection.defaultHandler, () -> throttle(key, route));
+    }    
+}

--- a/ts-reaktive-akka/src/test/java/com/tradeshift/reaktive/akka/ThrottleDirectiveSpec.java
+++ b/ts-reaktive-akka/src/test/java/com/tradeshift/reaktive/akka/ThrottleDirectiveSpec.java
@@ -1,0 +1,95 @@
+package com.tradeshift.reaktive.akka;
+
+import static akka.http.javadsl.server.Directives.complete;
+import static akka.http.javadsl.server.Directives.parameter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.cuppa.Cuppa.afterEach;
+import static org.forgerock.cuppa.Cuppa.beforeEach;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
+import com.tradeshift.reaktive.throttle.ThrottleDirective;
+import com.typesafe.config.ConfigFactory;
+
+import akka.http.javadsl.ConnectHttp;
+import akka.http.javadsl.Http;
+import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.Route;
+
+@RunWith(CuppaRunner.class)
+public class ThrottleDirectiveSpec extends SharedActorSystemSpec {
+    private final Http http = Http.get(system);
+    
+    private ServerBinding server;
+
+    public ThrottleDirectiveSpec() {
+        super(ConfigFactory.parseResources("ThrottleDirectiveSpec.conf"));
+    }
+    
+    private HttpResponse makeRequest(String user) {
+        HttpResponse response;
+        try {
+            response = http.singleRequest(HttpRequest.GET("http://localhost:8173?user=" + user), materializer).toCompletableFuture().get(2, TimeUnit.SECONDS);
+            response.discardEntityBytes(materializer);
+            return response;
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    {
+        describe("ThrottleDirective.throttle", () -> {
+            beforeEach(() -> {
+                ThrottleDirective throttler = new ThrottleDirective(system, 3, Duration.of(2, ChronoUnit.SECONDS), 5);
+                Route route = parameter("user", user ->
+                    throttler.throttleSealed(user, () ->
+                        complete("OK")
+                    )
+                );
+                server = http.bindAndHandle(route.flow(system, materializer), ConnectHttp.toHost("127.0.0.1:8173"), materializer)
+                    .toCompletableFuture()
+                    .get(2, TimeUnit.SECONDS);
+            });
+            
+            afterEach(() -> server.unbind().toCompletableFuture().get(2, TimeUnit.SECONDS));
+            
+            it("should fail requests after all tokens are used up, but allow them again after a delay", () -> {
+                // Make 5 quick requests to use up all tokens
+                for (int i = 0; i < 5; i++) {
+                    HttpResponse response = makeRequest("justme");
+                    assertThat(response.status()).isEqualTo(StatusCodes.OK);
+                }
+                HttpResponse response = makeRequest("justme");
+                assertThat(response.status()).isEqualTo(StatusCodes.ENHANCE_YOUR_CALM);
+                
+                Thread.sleep(2500);
+                
+                response = makeRequest("justme");
+                assertThat(response.status()).isEqualTo(StatusCodes.OK);
+            });
+            
+            it("should not throttle requests for another user", () -> {
+                // Make 5 quick requests to use up all tokens
+                for (int i = 0; i < 5; i++) {
+                    makeRequest("one");
+                }
+                // Make a request as another user
+                HttpResponse response = makeRequest("two");
+                assertThat(response.status()).isEqualTo(StatusCodes.OK);
+            });
+        });
+    }
+}

--- a/ts-reaktive-akka/src/test/resources/ThrottleDirectiveSpec.conf
+++ b/ts-reaktive-akka/src/test/resources/ThrottleDirectiveSpec.conf
@@ -1,0 +1,19 @@
+akka {
+  actor {
+    provider = "akka.cluster.ClusterActorRefProvider"
+  }
+  
+  remote {
+    log-remote-lifecycle-events = off
+    netty.tcp {
+      hostname = "127.0.0.1"
+      port = 3833
+    }
+  }
+     
+  cluster {
+    seed-nodes = [
+      "akka.tcp://SharedActorSystemSpec@127.0.0.1:3833"
+    ]
+  }
+}  

--- a/ts-reaktive-akka/src/test/resources/log4j.xml
+++ b/ts-reaktive-akka/src/test/resources/log4j.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration>
+  <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out" />
+    <param name="Threshold" value="DEBUG" />
+    <layout class="org.apache.log4j.EnhancedPatternLayout">
+      <param name="ConversionPattern" value="%d{ABSOLUTE} %-5p [%c{1.}] %X{akkaSource} - %m%n" />
+    </layout>
+  </appender>
+  
+  <logger name="org.apache.cassandra"><level value="WARN" /></logger>
+  <logger name="com.datastax.driver"><level value="WARN" /></logger>
+  <logger name="io.netty"><level value="WARN" /></logger>
+  <logger name="Sigar"><level value="WARN"/></logger>
+  <logger name="org.apache.http"><level value="WARN"/></logger>
+  <logger name="org.mortbay"><level value="WARN"/></logger>
+  <logger name="akka"><level value="DEBUG"/></logger>
+  <logger name="org.apache.sshd"><level value="INFO"/></logger>
+  <logger name="org.apache.sshd.server.subsystem.sftp"><level value="DEBUG"/></logger>
+  
+  <root>
+    <priority value="DEBUG" />
+    <appender-ref ref="CONSOLE" />
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
The new ThrottleDirective can be used to rate limit API calls while
distinguishing different users by a String value. This value is
application-specific and can be anything (IP address, username, ...)

The rate limiting is applied across the whole cluster by using cluster
sharding.