### PR TITLE
Make PersistentActorSharding less smart, and have impl decide on prefix

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/PersistentActorSharding.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/PersistentActorSharding.java
@@ -21,36 +21,50 @@ import akka.persistence.AbstractPersistentActor;
  */
 public class PersistentActorSharding<C> {
     private final Props props;
-    private final String persistenceIdPrefix;
-    private final Function<C, String> persistenceIdPostfix;
+    private final Function<C, String> getEntityId;
     private final int numberOfShards;
+    private String typeName;
     
     /**
      * Creates a PersistentActorSharding for an actor that is created according to [props]. The actor must be a subclass of {@link AbstractPersistentActor}.
      * Entities will be sharded onto 256 shards.
      * 
-     * @param persistenceIdPrefix Fixed prefix for each persistence id. This is typically the name of your aggregate root, e.g. "document" or "user".
-     * @param persistenceIdPostfix Function that returns the last part of the persistence id that a command is routed to. This typically is the real ID of your entity, or UUID.
+     * @param typeName    Actor name of the top-level shard region actor. This must be unique for each PersistentActorSharding type.
+     * @param props       Props that is used to instantiate child actors on shards
+     * @param getEntityId Function that returns the entityId (=persistenceId, and child actor name) that a command is routed to. 
+     *                    This can be a UUID or the aggregate ID of your entity, possibly prefixed with a fixed static string to differentiate it
+     *                    from other types in a shared journal.
      */
-    public static <C> PersistentActorSharding<C> of(Props props, String persistenceIdPrefix, Function<C, String> persistenceIdPostfix) {
-        return new PersistentActorSharding<>(props, persistenceIdPrefix, persistenceIdPostfix, 256);
+    public static <C> PersistentActorSharding<C> of(String typeName, Props props, Function<C, String> getEntityId) {
+        return new PersistentActorSharding<>(typeName, props, getEntityId, 256);
     }
     
     /**
      * Creates a PersistentActorSharding for an actor that is created according to [props]. The actor must be a subclass of {@link AbstractPersistentActor}.
      *
+     * @param typeName    Actor name of the top-level shard region actor. This must be unique for each PersistentActorSharding type.
+     * @param props       Props that is used to instantiate child actors on shards
+     * @param getEntityId Function that returns the entityId (=persistenceId, and child actor name) that a command is routed to. 
+     *                    This can be a UUID or the aggregate ID of your entity, possibly prefixed with a fixed static string to differentiate it
+     *                    from other types in a shared journal.
      * @param numberOfShards Number of shards to divide all entity/persistence ids into. This can not be changed after the first run.
-     * @param persistenceIdPrefix Fixed prefix for each persistence id. This is typically the name of your aggregate root, e.g. "document" or "user".
-     * @param persistenceIdPostfix Function that returns the last part of the persistence id that a command is routed to. This typically is the real ID of your entity, or UUID.
      */
-    public static <C> PersistentActorSharding<C> of(Props props, String persistenceIdPrefix, Function<C, String> persistenceIdPostfix, int numberOfShards) {
-        return new PersistentActorSharding<>(props, persistenceIdPrefix, persistenceIdPostfix, numberOfShards);
+    public static <C> PersistentActorSharding<C> of(String typeName, Props props, Function<C, String> getEntityId, int numberOfShards) {
+        return new PersistentActorSharding<>(typeName, props, getEntityId, numberOfShards);
     }
     
-    protected PersistentActorSharding(Props props, String persistenceIdPrefix, Function<C, String> entityIdForCommand, int numberOfShards) {
+    /**
+     * @deprecated Use the variant where the lambda returns the whole whole entityId, since then the implementation is in full control.  
+     */
+    @Deprecated
+    public static <C> PersistentActorSharding<C> of(Props props, String persistenceIdPrefix, Function<C, String> persistenceIdPostfix) {
+        return of(persistenceIdPrefix, props, c -> persistenceIdPrefix + "_" + persistenceIdPostfix.apply(c));
+    }
+    
+    protected PersistentActorSharding(String typeName, Props props, Function<C, String> getEntityId, int numberOfShards) {
+        this.typeName = typeName;
         this.props = props;
-        this.persistenceIdPrefix = persistenceIdPrefix;
-        this.persistenceIdPostfix = entityIdForCommand;
+        this.getEntityId = getEntityId;
         this.numberOfShards = numberOfShards;
     }
 
@@ -79,27 +93,19 @@ public class PersistentActorSharding<C> {
      */
     public ActorRef shardRegion(ActorSystem system) {
         return ClusterSharding.get(system).start(
-            persistenceIdPrefix,
+            typeName,
             props,
             ClusterShardingSettings.create(system),
             messageExtractor);
     }
     
     /**
-     * Returns the postfix part of a generated persistence ID.
-     * @param persistenceId A persistenceId of an actor that was spawned by sending a command to it through the
-     * ActorRef returned by {@link #shardRegion}.
-     */
-    public String getPersistenceIdPostfix(String persistenceId) {
-        return persistenceId.substring(persistenceIdPrefix.length() + 1);
-    };
-    
-    /**
-     * Returns the entityId (=persistenceId) to which the given command should be routed
+     * Returns the entityId (=persistenceId, and actor name) to which the given command should be routed.
+     * The argument must be an instance of {@code C}.
      */
     @SuppressWarnings("unchecked")
     public String getEntityId(Object command) {
-        return persistenceIdPrefix + "_" + persistenceIdPostfix.apply((C) command);
+        return getEntityId.apply((C) command);
     }
     
     /**

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/actors/ReplicatedActorSharding.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/actors/ReplicatedActorSharding.java
@@ -14,29 +14,43 @@ import akka.actor.Props;
 public class ReplicatedActorSharding<C> extends PersistentActorSharding<C> {
 
     /**
-     * Creates a ReplicatedActorSharding for an actor that is created according to [props].
+     * Creates a ReplicatedActorSharding for an actor that is created according to [props]. The actor must be a subclass of {@link ReplicatedActor}.
      * Entities will be sharded onto 256 shards.
      * 
-     * @param persistenceIdPrefix Fixed prefix for each persistence id. This is typically the name of your aggregate root, e.g. "document" or "user".
-     * @param persistenceIdPostfix Function that returns the last part of the persistence id that a command is routed to. This typically is the real ID of your entity, or UUID.
+     * @param typeName    Actor name of the top-level shard region actor. This must be unique for each PersistentActorSharding type.
+     * @param props       Props that is used to instantiate child actors on shards
+     * @param getEntityId Function that returns the entityId (=persistenceId, and child actor name) that a command is routed to. 
+     *                    This can be a UUID or the aggregate ID of your entity, possibly prefixed with a fixed static string to differentiate it
+     *                    from other types in a shared journal.
      */
-    public static <C> ReplicatedActorSharding<C> of(Props props, String persistenceIdPrefix, Function<C, String> persistenceIdPostfix) {
-        return new ReplicatedActorSharding<>(props, persistenceIdPrefix, persistenceIdPostfix, 256);
+    public static <C> ReplicatedActorSharding<C> of(String typeName, Props props, Function<C, String> getEntityId) {
+        return new ReplicatedActorSharding<>(typeName, props, getEntityId, 256);
     }
     
     /**
-     * Creates a ReplicatedActorSharding for an actor that is created according to [props].
-     * 
+     * Creates a ReplicatedActorSharding for an actor that is created according to [props]. The actor must be a subclass of {@link ReplicatedActorS}.
+     *
+     * @param typeName    Actor name of the top-level shard region actor. This must be unique for each PersistentActorSharding type.
+     * @param props       Props that is used to instantiate child actors on shards
+     * @param getEntityId Function that returns the entityId (=persistenceId, and child actor name) that a command is routed to. 
+     *                    This can be a UUID or the aggregate ID of your entity, possibly prefixed with a fixed static string to differentiate it
+     *                    from other types in a shared journal.
      * @param numberOfShards Number of shards to divide all entity/persistence ids into. This can not be changed after the first run.
-     * @param persistenceIdPrefix Fixed prefix for each persistence id. This is typically the name of your aggregate root, e.g. "document" or "user".
-     * @param persistenceIdPostfix Function that returns the last part of the persistence id that a command is routed to. This typically is the real ID of your entity, or UUID.
      */
-    public static <C> ReplicatedActorSharding<C> of(Props props, String persistenceIdPrefix, Function<C, String> persistenceIdPostfix, int numberOfShards) {
-        return new ReplicatedActorSharding<>(props, persistenceIdPrefix, persistenceIdPostfix, numberOfShards);
+    public static <C> ReplicatedActorSharding<C> of(String typeName, Props props, Function<C, String> getEntityId, int numberOfShards) {
+        return new ReplicatedActorSharding<>(typeName, props, getEntityId, numberOfShards);
     }
     
-    protected ReplicatedActorSharding(Props props, String persistenceIdPrefix, Function<C, String> persistenceIdPostfix, int numberOfShards) {
-        super(props, persistenceIdPrefix, persistenceIdPostfix, numberOfShards);
+    /**
+     * @deprecated Use the variant where the lambda returns the whole whole entityId, since then the implementation is in full control.  
+     */
+    @Deprecated
+    public static <C> PersistentActorSharding<C> of(Props props, String persistenceIdPrefix, Function<C, String> persistenceIdPostfix) {
+        return of(persistenceIdPrefix, props, c -> persistenceIdPrefix + "_" + persistenceIdPostfix.apply(c));
+    }
+    
+    protected ReplicatedActorSharding(String typeName, Props props, Function<C, String> getEntityId, int numberOfShards) {
+        super(typeName, props, getEntityId, numberOfShards);
     }
 
     /**

--- a/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/NonReplicatedTestActor.java
+++ b/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/NonReplicatedTestActor.java
@@ -23,7 +23,7 @@ import scala.PartialFunction;
  */
 public class NonReplicatedTestActor extends AbstractStatefulPersistentActor<TestCommand, TestEvent, TestActorState> {
     public static final PersistentActorSharding<TestCommand> sharding =
-		PersistentActorSharding.of(Props.create(NonReplicatedTestActor.class), "testactor", c -> toJava(c.getAggregateId()).toString());
+		PersistentActorSharding.of("testactor", Props.create(NonReplicatedTestActor.class), c -> toJava(c.getAggregateId()).toString());
 
     public NonReplicatedTestActor() {
         super(TestCommand.class, TestEvent.class);

--- a/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/ReplicatedTestActor.java
+++ b/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/ReplicatedTestActor.java
@@ -19,7 +19,7 @@ import scala.PartialFunction;
 
 public class ReplicatedTestActor extends ReplicatedActor<TestCommand, TestEvent, TestActorState> {
     public static final ReplicatedActorSharding<TestCommand> sharding =
-        ReplicatedActorSharding.of(Props.create(ReplicatedTestActor.class), "testactor", c -> toJava(c.getAggregateId()).toString());
+        ReplicatedActorSharding.of("testactor", Props.create(ReplicatedTestActor.class), c -> toJava(c.getAggregateId()).toString());
 
     public ReplicatedTestActor() {
         super(TestCommand.class, TestEvent.class);


### PR DESCRIPTION
By simplifying the lambda that goes into PersistentActorSharding,
implementations can decide on their own rules of prefixing persistenceIds.
This also isolates the code that does the reverse a lot better.