### PR TITLE
Make command handlers asynchronous-first

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/AbstractCommandHandler.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/AbstractCommandHandler.java
@@ -1,59 +1,150 @@
 package com.tradeshift.reaktive.actors;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import io.vavr.collection.Seq;
+import io.vavr.collection.Vector;
 import io.vavr.control.Option;
 
-/** Base class for handlers that handle specific commands */
+/** 
+ * A command handler knows how to transform command into a result, asynchronously. 
+ * 
+ * Handlers can be chained like partial functions.
+ * 
+ * Implementations can extend this class to implement command handlers. An implementation MUST
+ * implement either {@link #handle(AbstractState, Object)} or {@link #handleAsync(AbstractState, Object)},
+ * but not both.
+ */
 public abstract class AbstractCommandHandler<C,E,S extends AbstractState<E,?>> {
     /**
-     * The state as it was before applying the command
+     * Returns a AbstractCommandHandler that tries all of the given handlers in sequence, applying the first one that matches.
      */
-    protected final S state;
-    /**
-     * The command being received
-     */
-    protected final C cmd;
-    protected final long now = System.currentTimeMillis();
-    
-    public AbstractCommandHandler(S state, C cmd) {
-        this.state = state;
-        this.cmd = cmd;
+    @SafeVarargs
+    public static <C,E,S extends AbstractState<E,?>> AbstractCommandHandler<C,E,S> all(AbstractCommandHandler<C,E,S>... handlers) {
+        return new AbstractCommandHandler<C,E,S>() {
+            @Override
+            public boolean canHandle(C cmd) {
+                for (int i = 0; i < handlers.length; i++) {
+                    if (handlers[i].canHandle(cmd)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            
+            @Override
+            public CompletionStage<Results<E>> handleAsync(S state, C cmd) {
+                for (int i = 0; i < handlers.length; i++) {
+                    if (handlers[i].canHandle(cmd)) {
+                        return handlers[i].handleAsync(state, cmd);
+                    }
+                }
+                throw new IllegalArgumentException("Trying to handle a command for which canHandle() returned false.");
+            }
+        };
     }
     
     /**
-     * Returns the events to be emitted as a result of applying the command
+     * Returns whether this handler can handle the given command.
      */
-    public abstract Seq<E> getEventsToEmit();
+    public abstract boolean canHandle(C cmd);
     
     /**
-     * Returns the reply to send back to sender() on successfully having applied the events returned from events()
-     * @param emittedEvents The list of events that was returned from getEventsToEmit() earlier.
-     * @param lastSequenceNr The current last sequence number emitted on any event
+     * Returns the asynchronous result of handling the given command. 
      */
-    public abstract Object getReply(Seq<E> emittedEvents, long lastSequenceNr);
-
+    public CompletionStage<Results<E>> handleAsync(S state, C cmd) {
+        return CompletableFuture.completedFuture(handle(state, cmd));    
+    }
+    
     /**
-     * Returns the reply to send back to sender() on determining that the command has already been applied and was idempotent.
-     * @param lastSequenceNr The current last sequence number emitted on any event
+     * For non-asynchronous handlers, returns the direct result of handling the given command.
+     * 
+     * Implementations that don't need to do any asynchronous work in order to process a command
+     * can override this function (which {@link #handleAsync(AbstractState, Object)} will then invoke).
      */
-    public Object getIdempotentReply(long lastSequenceNr) {
-        throw new UnsupportedOperationException("Must implement getIdempotentReply() if overriding isAlreadyApplied()");
+    protected Results<E> handle(S state, C cmd) {
+        throw new UnsupportedOperationException("Sub-classes of AbstractCommandHandler need to implement either handleAsync or handle.");
     }
 
     /**
-     * Returns whether the current state indicates that the command was already applied (is idempotent)
+     * Returns a new command handler that first tries this handler and then {@code other}.
      */
-    public boolean isAlreadyApplied() {
-        return false;
+    public AbstractCommandHandler<C,E,S> orElse(AbstractCommandHandler<? super C, ? extends E, ? super S> other) {
+        AbstractCommandHandler<C, E, S> me = this;
+        return new AbstractCommandHandler<C,E,S>() {
+            @Override
+            public boolean canHandle(C cmd) {
+                return me.canHandle(cmd) || other.canHandle(cmd);
+            }
+            
+            @Override
+            public CompletionStage<Results<E>> handleAsync(S state, C cmd) {
+                if (me.canHandle(cmd)) {
+                    return me.handleAsync(state, cmd);
+                } else {
+                    return other.handleAsync(state, cmd).thenApply(Results::cast);
+                }
+            }
+        };
     }
-
-    /**
-     * Validates the given command. Default implementation accepts all commands.
-     * @param lastSequenceNr The current last sequence number emitted on any earlier event
-     * @return Any validation error that should be sent back to sender() in case the command is invalid,
-     *         or Optional.absent() in case the command is valid.
+    
+    /** 
+     * All the information that controls what should happen as a result of handling a command.
      */
-    public Option<Object> getValidationError(long lastSequenceNr) {
-        return Option.none();
+    public static abstract class Results<E> {
+        /**
+         * Results are covariant in E, i.e. a Result<U> is a Result<T> when U extends T.
+         */
+        @SuppressWarnings("unchecked")
+        public static <T,U extends T> Results<T> cast(Results<U> results) {
+            return (Results<T>) results;
+        }
+        
+        /**
+         * The timestamp at which the results were created (convenient to use as timestamp in events)
+         */
+        protected final long now = System.currentTimeMillis();
+        
+        /**
+         * Returns the events to be emitted as a result of applying the command. 
+         * 
+         * By default, no events are emitted (which is appropriate for read-only commands).
+         */
+        public Seq<E> getEventsToEmit() {
+            return Vector.empty();
+        }
+        
+        /**
+         * Returns the reply to send back to sender() on successfully having applied the events returned from events()
+         * @param emittedEvents The list of events that was returned from getEventsToEmit() earlier.
+         * @param lastSequenceNr The current last sequence number emitted on any event
+         */
+        public abstract Object getReply(Seq<E> emittedEvents, long lastSequenceNr);
+    
+        /**
+         * Returns the reply to send back to sender() on determining that the command has already been applied and was idempotent.
+         * @param lastSequenceNr The current last sequence number emitted on any event
+         */
+        public Object getIdempotentReply(long lastSequenceNr) {
+            throw new UnsupportedOperationException("Must implement getIdempotentReply() if overriding isAlreadyApplied()");
+        }
+    
+        /**
+         * Returns whether the current state indicates that the command was already applied (is idempotent)
+         */
+        public boolean isAlreadyApplied() {
+            return false;
+        }
+    
+        /**
+         * Validates the given command. Default implementation accepts all commands.
+         * @param lastSequenceNr The current last sequence number emitted on any earlier event
+         * @return Any validation error that should be sent back to sender() in case the command is invalid,
+         *         or Optional.absent() in case the command is valid.
+         */
+        public Option<Object> getValidationError(long lastSequenceNr) {
+            return Option.none();
+        }
     }
 }

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/AbstractStatefulPersistentActor.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/AbstractStatefulPersistentActor.java
@@ -5,7 +5,6 @@ import static akka.pattern.PatternsCS.pipe;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.typesafe.config.Config;
@@ -17,7 +16,6 @@ import akka.cluster.sharding.ShardRegion;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
 import akka.japi.Procedure;
-import akka.japi.pf.PFBuilder;
 import akka.japi.pf.ReceiveBuilder;
 import akka.persistence.AbstractPersistentActor;
 import akka.persistence.SnapshotOffer;
@@ -25,7 +23,6 @@ import akka.persistence.journal.Tagged;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Vector;
 import io.vavr.control.Option;
-import scala.PartialFunction;
 import scala.concurrent.duration.Duration;
 
 /**
@@ -53,20 +50,22 @@ public abstract class AbstractStatefulPersistentActor<C,E,S extends AbstractStat
     
     private S state = initialState();
 
-    //IDEA: We can save 8*3 bytes per actor by pushing these 3 fields down into a type class, since the fields have the same value for every type of actor...
+    //IDEA: We can save memory per actor by pushing these fields down into a type class, since the fields have the same value for every type of actor...
     protected final Class<E> eventType;
     protected final Class<C> commandType;
     private final String tagName;
+    private final AbstractCommandHandler<C,E,S> handlers;
     
     public static String getEventTag(Config config, Class<?> eventType) {
         ConfigObject tags = config.getConfig("ts-reaktive.actors.tags").root();
         return (String) tags.getOrDefault(eventType.getName(), ConfigValueFactory.fromAnyRef(eventType.getSimpleName())).unwrapped();
     }
     
-    public AbstractStatefulPersistentActor(Class<C> commandType, Class<E> eventType) {
+    public AbstractStatefulPersistentActor(Class<C> commandType, Class<E> eventType, AbstractCommandHandler<C,E,S> handlers) {
         this.commandType = commandType;
         this.eventType = eventType;
         this.tagName = getEventTag(context().system().settings().config(), eventType);
+        this.handlers = handlers;
         context().setReceiveTimeout(Duration.fromNanos(getPassivateTimeout().toNanos()));
     }
 
@@ -74,14 +73,14 @@ public abstract class AbstractStatefulPersistentActor<C,E,S extends AbstractStat
         return context().system().settings().config().getDuration("ts-reaktive.actors.passivate-timeout");
     }
 
+    @SuppressWarnings({"unchecked"})
     @Override
     public Receive createReceive() {
         return ReceiveBuilder.create()
-            .match(CommandWithHandler.class, m -> {
-                @SuppressWarnings("unchecked") CommandWithHandler msg = m;
-                handleCommand(msg.command, msg.handler);
+            .match(AbstractCommandHandler.Results.class, msg -> {
+                handleResults((AbstractCommandHandler.Results<E>) msg);
             })
-            .match(commandType, this::handleCommand)
+            .match(commandType, this::canHandleCommand, this::handleCommand)
             .matchEquals(ReceiveTimeout.getInstance(), msg -> passivate())
             .match(Stop.class, msg -> context().stop(self()))
             .build();
@@ -108,37 +107,6 @@ public abstract class AbstractStatefulPersistentActor<C,E,S extends AbstractStat
     }
 
     /**
-     * Returns the partial function that asynchronously handles commands sent to this actor, allowing multiple
-     * concurrent commands being asynchronously in-flight at the same time. Once the CompletionStage are resolved,
-     * the individual handlers are of course executed sequentially using the actor's normal message processing mechanism.
-     * 
-     * Incoming commands are first tried using applyCommandAsync(), and then applyCommand() if unhandled.
-     * 
-     * The default implementation is empty, i.e. all incoming commands are handled by applyCommand().
-     * 
-     * Use {@link PFBuilder} to create partial functions.
-     */
-    protected PartialFunction<C, CompletionStage<? extends AbstractCommandHandler<C,E,S>>> applyCommandAsync() {
-        return new PFBuilder<C, CompletionStage<? extends AbstractCommandHandler<C,E,S>>>().build();
-    }
-    
-    /**
-     * Returns a {@link PFBuilder} of the right type for applyCommandAsync. Use this method to trim down
-     * on repeating code in your actor class.
-     */
-    protected PFBuilder<C, CompletionStage<? extends AbstractCommandHandler<C,E,S>>> applyCommandAsyncBuilder() {
-        return new PFBuilder<>();
-    }
-    
-    /**
-     * Returns the partial function that handles commands sent to this actor.
-     * Incoming commands are first tried using applyCommandAsync(), and then applyCommand() if unhandled.
-     * 
-     * Use {@link PFBuilder} to create partial functions.
-     */
-    protected abstract PartialFunction<C, ? extends AbstractCommandHandler<C,E,S>> applyCommand();
-    
-    /**
      * Returns the initial value the state should be, when the actor is just created.
      * 
      * Although the implementation of this method is free to investigate the actor's context() and its environment, it must
@@ -147,35 +115,40 @@ public abstract class AbstractStatefulPersistentActor<C,E,S extends AbstractStat
     protected abstract S initialState();
     
     /**
-     * Looks up a handler using handleCommandAsync() or handleCommand(), and then invokes
-     * handleCommand(cmd, handler) once the handler is resolved.
+     * Returns whether any handler can handle the given command.
+     */
+    protected boolean canHandleCommand(C cmd) {
+        return handlers.canHandle(cmd);
+    }
+    
+    /**
+     * Handles the given command, and processes its results once they come in asynchronously. 
+     * 
+     * Must only be invoked if {@link #canHandleCommand(Object)} has returned true for this command.
      */
     protected void handleCommand(C cmd) {
-        if (applyCommandAsync().isDefinedAt(cmd)) {
-            log.info("{} async processing {}", self().path(), cmd);
-            pipe(applyCommandAsync().apply(cmd).thenApply(handler -> new CommandWithHandler(cmd, handler)), context().dispatcher()).to(self(), sender());
-        } else {
-            log.info("{} processing {}", self().path(), cmd);
-            handleCommand(cmd, applyCommand().apply(cmd));
-        }
+        // FIXME We need to uphold command ordering for the same sender (just like akka does for normal messages).
+        // Hence, we need to stash subsequent messages from the same sender, while one message from that sender is still
+        // being piped.
+        pipe(handlers.handleAsync(state, cmd), context().dispatcher()).to(self(), sender());
     }
 
     /**
-     * Executes the given command using the given handler, emitting any events, and responding to sender().
+     * Applies the results that came in from a handler, emitting any events, and responding to sender().
      */
-    protected void handleCommand(C cmd, AbstractCommandHandler<C, E, S> handler) {
-        Option<Object> error = handler.getValidationError(lastSequenceNr());
+    protected void handleResults(AbstractCommandHandler.Results<E> results) {
+        Option<Object> error = results.getValidationError(lastSequenceNr());
         if (error.isDefined()) {
             log.debug("  invalid: {}", error.get());
             sender().tell(error.get(), self());
-        } else if (handler.isAlreadyApplied()) {
+        } else if (results.isAlreadyApplied()) {
             log.debug("  was already applied.");
-            sender().tell(handler.getIdempotentReply(lastSequenceNr()), self());
+            sender().tell(results.getIdempotentReply(lastSequenceNr()), self());
         } else {
-            Seq<E> events = handler.getEventsToEmit();
+            Seq<E> events = results.getEventsToEmit();
             log.debug("  emitting {}", events);
             if (events.isEmpty()) {
-                sender().tell(handler.getReply(events, lastSequenceNr()), self());
+                sender().tell(results.getReply(events, lastSequenceNr()), self());
             } else {
                 if (lastSequenceNr() == 0) {
                     validateFirstEvent(events.head());
@@ -183,7 +156,7 @@ public abstract class AbstractStatefulPersistentActor<C,E,S extends AbstractStat
                 AtomicInteger need = new AtomicInteger(events.size());
                 persistAllEvents(events, evt -> {
                     if (need.decrementAndGet() == 0) {
-                        sender().tell(handler.getReply(events, lastSequenceNr()), self());
+                        sender().tell(results.getReply(events, lastSequenceNr()), self());
                     }
                 });
             }
@@ -301,14 +274,4 @@ public abstract class AbstractStatefulPersistentActor<C,E,S extends AbstractStat
         private static final long serialVersionUID = 1L;
     }
     private static final Stop STOP = new Stop();
-    
-    private class CommandWithHandler {
-        private final C command;
-        private final AbstractCommandHandler<C, E, S> handler;
-        
-        public CommandWithHandler(C command, AbstractCommandHandler<C, E, S> handler) {
-            this.command = command;
-            this.handler = handler;
-        }
-    }
 }

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/actors/ReplicatedActor.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/actors/ReplicatedActor.java
@@ -3,6 +3,7 @@ package com.tradeshift.reaktive.replication.actors;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.tradeshift.reaktive.actors.AbstractCommandHandler;
 import com.tradeshift.reaktive.actors.AbstractState;
 import com.tradeshift.reaktive.actors.AbstractStatefulPersistentActor;
 import com.tradeshift.reaktive.protobuf.Query;
@@ -40,8 +41,8 @@ import static io.vavr.control.Option.some;
 public abstract class ReplicatedActor<C,E,S extends AbstractState<E,S>> extends AbstractStatefulPersistentActor<C,E,S> {
     private final Replication replication = ReplicationId.INSTANCE.get(context().system());
     
-    public ReplicatedActor(Class<C> commandType, Class<E> eventType) {
-        super(commandType, eventType);
+    public ReplicatedActor(Class<C> commandType, Class<E> eventType, AbstractCommandHandler<C, E, S> handler) {
+        super(commandType, eventType, handler);
     }
     
     protected EventClassifier<E> classifier() {

--- a/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/ReplicatedTestActor.java
+++ b/ts-reaktive-replication/src/test/java/com/tradeshift/reaktive/replication/ReplicatedTestActor.java
@@ -2,7 +2,11 @@ package com.tradeshift.reaktive.replication;
 
 import static com.tradeshift.reaktive.protobuf.UUIDs.toJava;
 
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
 import com.tradeshift.reaktive.actors.AbstractCommandHandler;
+import com.tradeshift.reaktive.actors.AbstractCommandHandler.Results;
 import com.tradeshift.reaktive.replication.TestData.TestCommand;
 import com.tradeshift.reaktive.replication.TestData.TestEvent;
 import com.tradeshift.reaktive.replication.actors.ReplicatedActor;
@@ -11,18 +15,62 @@ import com.tradeshift.reaktive.replication.actors.ReplicatedActorSharding;
 import akka.Done;
 import akka.actor.Props;
 import akka.actor.Status.Failure;
-import akka.japi.pf.PFBuilder;
 import io.vavr.collection.Seq;
 import io.vavr.collection.Vector;
 import io.vavr.control.Option;
-import scala.PartialFunction;
 
 public class ReplicatedTestActor extends ReplicatedActor<TestCommand, TestEvent, TestActorState> {
     public static final ReplicatedActorSharding<TestCommand> sharding =
         ReplicatedActorSharding.of("testactor", Props.create(ReplicatedTestActor.class), c -> toJava(c.getAggregateId()).toString());
+    
+    private static class Handler extends AbstractCommandHandler<TestCommand, TestEvent, TestActorState> {
+        private final Predicate<TestCommand> canHandle;
+        private final BiFunction<TestActorState, TestCommand, Results<TestEvent>> handle;
+        
+        public Handler(Predicate<TestCommand> canHandle, BiFunction<TestActorState, TestCommand, Results<TestEvent>> handle) {
+            this.canHandle = canHandle;
+            this.handle = handle;
+        }
+
+        @Override
+        public boolean canHandle(TestCommand cmd) {
+            return canHandle.test(cmd);
+        }
+        
+        @Override
+        protected Results<TestEvent> handle(TestActorState state, TestCommand cmd) {
+            return handle.apply(state, cmd);
+        }
+    }
 
     public ReplicatedTestActor() {
-        super(TestCommand.class, TestEvent.class);
+        super(TestCommand.class, TestEvent.class, 
+            new Handler(c -> c.hasRead(), (state, c) -> new Results<TestEvent>() {
+                @Override
+                public Option<Object> getValidationError(long lastSequenceNr) {
+                    if (state.getMsg() == null) {
+                        return Option.some(new Failure(new RuntimeException("Nothing written yet")));
+                    } else {
+                        return Option.none();
+                    }
+                }
+                
+                @Override
+                public Object getReply(Seq<TestEvent> emittedEvents, long lastSequenceNr) {
+                    return state.getMsg();
+                }                
+            }).orElse(new Handler(c -> c.hasWrite(), (state, c) -> new Results<TestEvent>() {
+                @Override
+                public Seq<TestEvent> getEventsToEmit() {
+                    return Vector.of(TestEvent.newBuilder().setMsg(c.getWrite().getMsg()).build());
+                }
+
+                @Override
+                public Object getReply(Seq<TestEvent> emittedEvents, long lastSequenceNr) {
+                    return Done.getInstance();
+                }                
+            }))
+        );
     }
     
     @Override
@@ -46,51 +94,7 @@ public class ReplicatedTestActor extends ReplicatedActor<TestCommand, TestEvent,
     }
 
     @Override
-    protected PartialFunction<TestCommand, ? extends AbstractCommandHandler<TestCommand, TestEvent, TestActorState>> applyCommand() {
-        return new PFBuilder<TestCommand,Handler>()
-            .match(TestCommand.class, c -> c.hasRead(), c -> new Handler(c) {
-                @Override
-                public Option<Object> getValidationError(long lastSequenceNr) {
-                    if (state.getMsg() == null) {
-                        return Option.some(new Failure(new RuntimeException("Nothing written yet")));
-                    } else {
-                        return Option.none();
-                    }
-                }
-                
-                @Override
-                public Seq<TestEvent> getEventsToEmit() {
-                    return Vector.empty();
-                }
-
-                @Override
-                public Object getReply(Seq<TestEvent> emittedEvents, long lastSequenceNr) {
-                    return state.getMsg();
-                }
-            })
-            .match(TestCommand.class, c -> c.hasWrite(), c -> new Handler(c) {
-                @Override
-                public Seq<TestEvent> getEventsToEmit() {
-                    return Vector.of(TestEvent.newBuilder().setMsg(c.getWrite().getMsg()).build());
-                }
-
-                @Override
-                public Object getReply(Seq<TestEvent> emittedEvents, long lastSequenceNr) {
-                    return Done.getInstance();
-                }
-            })
-            .build();
-            
-    }
-    
-    @Override
     protected TestEvent createMigrationEvent() {
     	return TestEvent.newBuilder().setMsg("dc:local").build();
-    }
-    
-    private abstract class Handler extends AbstractCommandHandler<TestCommand, TestEvent, TestActorState> {
-        public Handler(TestCommand cmd) {
-            super(getState(), cmd);
-        }
-    }
+    }    
 }


### PR DESCRIPTION
When implementing actors, we are seeing more and more async "setup" code
needing to do checks, pull in extra information, etc, taking place before
the real Handler is invoked. This asyncronous activity should ideally
be part of the Handler class itself.

This commit re-defines AbstractCommandHandler as a partial function from
(Command, State) to CompletionStage(Results), where Results encapsulates
what was previously in AbstractCommandHandler.

Existing implementations need to rework their code, with examples present
in the changes to ReplicatedTestActor, NonReplicatedTestActor and
AbstractStatefulPersistentActorSpec in this commit.