### PR TITLE
Revert part of e9d0552 since it breaks 2.11 compatibility

### DIFF
--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/VisibilityCassandraSession.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/VisibilityCassandraSession.java
@@ -1,13 +1,14 @@
 package com.tradeshift.reaktive.replication;
 
 
+import static scala.collection.JavaConverters.asScalaBufferConverter;
+
 import com.tradeshift.reaktive.cassandra.CassandraSession;
 import com.typesafe.config.Config;
 
 import akka.actor.ActorSystem;
 import akka.persistence.cassandra.CassandraPluginConfig;
 import io.vavr.collection.Vector;
-import scala.collection.JavaConverters;
 
 public class VisibilityCassandraSession extends CassandraSession {
     private final String keyspace;
@@ -25,7 +26,7 @@ public class VisibilityCassandraSession extends CassandraSession {
         String replStrategy = CassandraPluginConfig.getReplicationStrategy(
             config.getString("replication-strategy"),
             config.getInt("replication-factor"),
-            JavaConverters.asScalaBuffer(config.getStringList("data-center-replication-factors")));
+            asScalaBufferConverter(config.getStringList("data-center-replication-factors")).asScala());
         String keyspace = config.getString("keyspace");
 
         return Vector.of(


### PR DESCRIPTION
The asScalaBuffer method on JavaConversion was introduced in Scala 2.12
with the AsScalaConverters trait, so it's not available in 2.11.