### PR TITLE
Fix delimited protobuf parsing issue.

### DIFF
--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/protobuf/DelimitedProtobufFramingSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/protobuf/DelimitedProtobufFramingSpec.java
@@ -49,5 +49,31 @@ public class DelimitedProtobufFramingSpec extends SharedActorSystemSpec {{
                 .get(1, TimeUnit.SECONDS)
             ).hasMessageContaining("malformed varint");
         });
+
+        it("should emit the deframed messages even if the stream is splitted in the middle of a size frame", () -> {
+            //1000 as a 2-byte unsigned int (used in delimited protobuf serialization)
+            ByteString thousand = ByteString.fromInts(-24, 7); 
+            ByteString aThousandOnes = Vector.fill(1000, () -> ByteString.fromInts(1))
+                .fold(ByteString.empty(), ByteString::concat);
+            assertThat(Source
+                    .from(Vector.of(4, 0, 0, 0, 0).map(ByteString::fromInts)
+                        .append(thousand)
+                        .append(aThousandOnes))
+                    .fold(ByteString.empty(), ByteString::concat)
+                    .mapConcat(bs -> {
+                        byte[] bytes = bs.toArray();
+                        //split from the middle of the second size frame (1000)
+                        byte[] part1 = new byte[6];
+                        byte[] part2 = new byte[1001];
+                        System.arraycopy(bytes, 0, part1, 0, 6);
+                        System.arraycopy(bytes, 6, part2, 0, 1001);
+                        return Vector.of(ByteString.fromArray(part1), ByteString.fromArray(part2));
+                    })
+                    .via(DelimitedProtobufFraming.instance)
+                    .runWith(Sink.seq(), materializer)
+                    .toCompletableFuture()
+                    .get(1, TimeUnit.SECONDS)
+            ).containsExactly(ByteString.fromInts(0, 0, 0, 0), aThousandOnes);
+        });
     });
 }}


### PR DESCRIPTION
While parsing delimited protobuf messages, when a 'message size' value spans to multiple bytes, some existing deframed messages are not emitted.
This commit fixes the issue by keeping the state of the deframed buffer between stream graph stage invocations.