### PR TITLE
Fix blind cast to the wrong type

### DIFF
--- a/ts-reaktive-marshal/src/main/java/com/tradeshift/reaktive/json/ObjectWriteProtocol.java
+++ b/ts-reaktive-marshal/src/main/java/com/tradeshift/reaktive/json/ObjectWriteProtocol.java
@@ -35,7 +35,7 @@ public class ObjectWriteProtocol<T> implements WriteProtocol<JSONEvent, T> {
     }
     
     public ObjectWriteProtocol(WriteProtocol<JSONEvent, T> inner) {
-        this(Vector.of((Protocol<JSONEvent, ?>)inner), Arrays.asList(Function1.identity()), Vector.empty());
+        this(Vector.of((WriteProtocol<JSONEvent, ?>)inner), Arrays.asList(Function1.identity()), Vector.empty());
     }
     
     ObjectWriteProtocol(


### PR DESCRIPTION
ObjectWriteProtocol was casting its inner arguments to Protocol (instead
of WriteProtocol), causing JSONProtocol.object() not to be usable with
write-only protocols. This commit fixes that.