### PR TITLE
Don't log an error when XSD validation fails

### DIFF
--- a/ts-reaktive-marshal-akka/src/main/java/com/tradeshift/reaktive/marshal/stream/SchemaValidatorFlow.java
+++ b/ts-reaktive-marshal-akka/src/main/java/com/tradeshift/reaktive/marshal/stream/SchemaValidatorFlow.java
@@ -94,10 +94,10 @@ public class SchemaValidatorFlow extends GraphStage<FlowShape<XMLEvent, XMLEvent
                     }
                     try {
                         Stax.apply(event, handler);
+                        push(out, event);
                     } catch (SAXParseException x) {
-                        throw x;
+                        failStage(x);
                     }
-                    push(out, event);
                 }
             });
         }};


### PR DESCRIPTION
By default, RepointableActorRef logs an ERROR if a graph stage throws an
exception.

Rather, just fail the stage (using failStage()), and whoever is running
the graph can decide what to do with the exception.