### PR TITLE
Allow multiple workers in MaterializerActor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,7 @@ lazy val projectSettings = Seq(
   protobufRunProtoc in ProtobufConfig := { args =>
     com.github.os72.protocjar.Protoc.runProtoc("-v261" +: args.toArray)
   },
+  testOptions += Tests.Argument(TestFrameworks.JUnit, "-a"),
   libraryDependencies ++= Seq(
     "io.vavr" % "vavr" % "0.9.0",
     "org.slf4j" % "slf4j-api" % "1.7.12",

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/acl/ACL.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/acl/ACL.java
@@ -60,6 +60,11 @@ public class ACL<R,C> {
         return this;
     }
 
+    /** Returns all the rights granted in this ACL */
+    public Map<R,Set<UUID>> getGranted() {
+        return entries;
+    }
+
     /**
      * Returns whether the given target UUID is registered as having the given right (directly).
      * This function doesn't take any special "admin" rights into account.

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/acl/GroupedUserACL.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/acl/GroupedUserACL.java
@@ -7,6 +7,7 @@ import com.tradeshift.reaktive.protobuf.UUIDs;
 
 import io.vavr.Function1;
 import io.vavr.collection.HashSet;
+import io.vavr.collection.Map;
 import io.vavr.collection.Set;
 import io.vavr.control.Option;
 
@@ -118,5 +119,14 @@ public class GroupedUserACL<R extends Enum<R>,C> {
     public boolean isOnlyGrantedToGroup(UUID groupId, R right) {
         return groupAcl.isOnlyGrantedTo(groupId, right);
     }
-}
 
+    /** Returns, per right, the set of users that have been granted that right. */
+    public Map<R,Set<UUID>> getGrantedUsers() {
+        return userAcl.getGranted();
+    }
+
+    /** Returns, per right, the set of groups that have been granted that right. */
+    public Map<R,Set<UUID>> getGrantedGroups() {
+        return userAcl.getGranted();
+    }
+}

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerMetrics.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerMetrics.java
@@ -6,23 +6,26 @@ import io.vavr.collection.HashMap;
 import kamon.Kamon;
 import kamon.metric.Counter;
 import kamon.metric.Histogram;
+import kamon.metric.HistogramMetric;
 import kamon.metric.MeasurementUnit;
 
 public class MaterializerMetrics {
+    private final HashMap<String, String> baseTags;
+    private final Counter events;
+    private final Counter restarts;
+    private final Histogram reimportRemaining;
+    private final HistogramMetric offset;
 
     public MaterializerMetrics(String name) {
-        Map<String, String> tags = HashMap.of("journal-materializer", name).toJavaMap();
+        baseTags = HashMap.of("journal-materializer", name);
+        Map<String, String> tags = baseTags.toJavaMap();
         this.events = Kamon.counter("journal-materializer.events").refine(tags);
         this.restarts = Kamon.counter("journal-materializer.restarts").refine(tags);
         this.reimportRemaining = Kamon.histogram("journal-materializer.reimport-remaining", MeasurementUnit.time().milliseconds()).refine(tags);
         this.offset = Kamon.histogram("journal-materializer.offset",
-            MeasurementUnit.time().milliseconds()).refine(tags);
+            MeasurementUnit.time().milliseconds());
     }
 
-    private final Counter events;
-    private final Counter restarts;
-    private final Histogram offset;
-    private final Histogram reimportRemaining;
 
     public Counter getEvents() {
         return events;
@@ -32,8 +35,8 @@ public class MaterializerMetrics {
         return restarts;
     }
 
-    public Histogram getOffset() {
-        return offset;
+    public Histogram getOffset(int index) {
+        return offset.refine(baseTags.put("index", String.valueOf(index)).toJavaMap());
     }
 
     public Histogram getReimportRemaining() {

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerWorkers.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerWorkers.java
@@ -1,0 +1,222 @@
+package com.tradeshift.reaktive.materialize;
+
+import static com.tradeshift.reaktive.protobuf.UUIDs.toJava;
+import static com.tradeshift.reaktive.protobuf.UUIDs.toProtobuf;
+
+import java.time.Instant;
+import java.time.temporal.TemporalAmount;
+import java.util.UUID;
+import java.util.function.Function;
+
+import com.tradeshift.reaktive.protobuf.MaterializerActor.MaterializerActorEvent;
+import com.tradeshift.reaktive.protobuf.MaterializerActor.MaterializerActorEvent.Worker;
+import com.tradeshift.reaktive.protobuf.UUIDs;
+
+import io.vavr.collection.Seq;
+import io.vavr.collection.Vector;
+import io.vavr.control.Option;
+
+/**
+ * Contains the state of workers for a MaterializerActor, i.e. the timestamp each worker is currently working on, and the
+ * timestamp when it's finished.
+ **/
+public class MaterializerWorkers {
+    public static MaterializerWorkers empty(TemporalAmount rollback) {
+        return new MaterializerWorkers(Vector.empty(), rollback);
+    }
+
+    @SafeVarargs
+    public static MaterializerWorkers build(TemporalAmount rollback, Function<MaterializerWorkers,MaterializerActorEvent>... f) {
+        MaterializerWorkers w = MaterializerWorkers.empty(rollback);
+        for (int i = 0; i < f.length; i++) {
+            w = w.applyEvent(f[i].apply(w));
+        }
+        return w;
+    }
+
+    private final Seq<Worker> workers;
+    private final TemporalAmount rollback;
+
+    private MaterializerWorkers(Seq<Worker> workers, TemporalAmount rollback) {
+        this.workers = workers;
+        this.rollback = rollback;
+    }
+
+    public boolean isEmpty() {
+        return workers.isEmpty();
+    }
+
+    public MaterializerWorkers initialize() {
+        if (isEmpty()) {
+            return new MaterializerWorkers(Vector.of(Worker.newBuilder()
+                .setId(toProtobuf(UUID.randomUUID()))
+                .setTimestamp(0L)
+                .build()), rollback);
+        } else {
+            // already initialized;
+            return this;
+        }
+    }
+
+    public MaterializerWorkers applyEvent(long event) {
+        if (workers.size() == 0) {
+            return new MaterializerWorkers(Vector.of(Worker.newBuilder()
+                .setId(toProtobuf(UUID.randomUUID()))
+                .setTimestamp(event)
+                .build()), rollback);
+        } else if (workers.size() == 1) {
+            return new MaterializerWorkers(Vector.of(workers.head().toBuilder()
+                .setTimestamp(event)
+                .build()), rollback);
+        } else {
+            throw new IllegalStateException("Encountered legacy Long event " + event
+                + " AFTER having more than 1 worker: " + workers);
+        }
+    }
+
+    public MaterializerWorkers applyEvent(MaterializerActorEvent event) {
+        return new MaterializerWorkers(Vector.ofAll(event.getWorkerList()), rollback);
+    }
+
+    /**
+     * Applies a worker reporting back timestamp progress.
+     *
+     * @param timestamp The timestamp that the worker has completed processing on.
+     *
+     * @return An event to emit with the new restart indexes. In case the worker was done, it will
+     * be absent from the emitted event.
+     */
+    public MaterializerActorEvent onWorkerProgress(UUID workerId, Instant timestamp) {
+        int index = workers.map(Worker::getId).indexOf(toProtobuf(workerId));
+        if (index == -1) {
+            new IllegalArgumentException("Unknown worker: " + workerId);
+        }
+        Worker worker = workers.apply(index);
+        if (worker.hasEndTimestamp() && timestamp.toEpochMilli() >= worker.getEndTimestamp()) {
+            return MaterializerActorEvent.newBuilder()
+                .addAllWorker(workers.removeAt(index))
+                .build();
+        } else {
+            // We're now positively done with timestamp [o].
+            // If [o] is long enough ago, we can start with [o+1] next time. Otherwise, we start again at now() minus rollback.
+            Instant now = Instant.now();
+            long newTimestamp;
+            if (timestamp.isBefore(now.minus(rollback))) {
+                newTimestamp = timestamp.toEpochMilli() + 1;
+            } else {
+                newTimestamp = now.minus(rollback).toEpochMilli();
+            }
+
+            return toEvent(workers.update(index, worker.toBuilder()
+                .setTimestamp(newTimestamp)
+                .build()
+            ));
+        }
+    }
+
+    private static MaterializerActorEvent toEvent(Seq<Worker> workers) {
+        return MaterializerActorEvent.newBuilder() .addAllWorker(workers) .build();
+    }
+
+    /**
+     * Attempts to start a new worker which should start at the given start timestamp.
+     *
+     * If the start timestamp is close to another worker's timestamp, no worker is started since
+     * that would be non-sensical.
+     *
+     * @return An event to emit with new restart indexes.
+     */
+    public MaterializerActorEvent startWorker(Instant startTimestamp) {
+        long t = startTimestamp.toEpochMilli();
+        if (workers.isEmpty()) {
+            return toEvent(Vector.of(Worker.newBuilder()
+                .setId(toProtobuf(UUID.randomUUID()))
+                .setTimestamp(t)
+                .build()
+            ));
+        }
+
+        if (workers.exists(w -> Math.abs(w.getTimestamp() - t) < 1000)) {
+            // Start timestamp too close to an existing worker, so don't start a new one.
+            return toEvent(workers);
+        }
+
+        int index = workers.indexWhere(w -> w.getTimestamp() >= t);
+        if (index == 0) {
+            // Prepend to beginning, run to timestamp of current first worker
+            return toEvent(workers
+                .insert(0, Worker.newBuilder()
+                    .setId(toProtobuf(UUID.randomUUID()))
+                    .setTimestamp(t)
+                    .setEndTimestamp(workers.head().getTimestamp())
+                    .build()
+                )
+            );
+        } else if (index == -1) {
+            // Append to end, make currently last worker only run until the timestamp we start at
+            return toEvent(workers
+                .update(workers.size() - 1, workers.apply(workers.size() - 1).toBuilder()
+                    .setEndTimestamp(t)
+                    .build()
+                )
+                .append(Worker.newBuilder()
+                    .setId(toProtobuf(UUID.randomUUID()))
+                    .setTimestamp(t)
+                    .build()
+                )
+            );
+        } else {
+            Worker w = workers.apply(index - 1);
+            // Workers that are not at the end are guaranteed to have an end timestamp.
+            if (w.getEndTimestamp() > t) {
+                return toEvent(workers
+                    .update(index - 1, w.toBuilder()
+                        .setEndTimestamp(t)
+                        .build()
+                    )
+                    .insert(index, Worker.newBuilder()
+                        .setId(toProtobuf(UUID.randomUUID()))
+                        .setTimestamp(t)
+                        .setEndTimestamp(w.getEndTimestamp())
+                        .build()
+                    )
+                );
+            } else {
+                // no need to adjust end timestamp of previous worker, just insert the new one
+                return toEvent(workers
+                    .insert(index, Worker.newBuilder()
+                        .setId(toProtobuf(UUID.randomUUID()))
+                        .setTimestamp(t)
+                        .setEndTimestamp(workers.apply(index).getTimestamp())
+                        .build()
+                    )
+                );
+            }
+        }
+    }
+
+    public Seq<UUID> getIds() {
+        return workers.map(Worker::getId).map(UUIDs::toJava);
+    }
+
+    public Instant getTimestamp(UUID workerId) {
+        return Instant.ofEpochMilli(get(workerId).getTimestamp());
+    }
+
+    public Option<Instant> getEndTimestamp(UUID workerId) {
+        Worker w = get(workerId);
+        return Option.when(w.hasEndTimestamp(), () -> Instant.ofEpochMilli(w.getEndTimestamp()));
+    }
+
+    private Worker get(UUID workerId) {
+        return workers.find(w -> w.getId().equals(toProtobuf(workerId))).getOrElseThrow(() ->
+            new IllegalArgumentException("Unknown worker: " + workerId)
+        );
+    }
+
+    @Override
+    public String toString() {
+        return workers.map(w -> String.format("%s: %s %s", toJava(w.getId()), Instant.ofEpochMilli(w.getTimestamp()),
+            w.hasEndTimestamp() ? "-> " + Instant.ofEpochMilli(w.getEndTimestamp()) : "")).mkString(", \n");
+    }
+}

--- a/ts-reaktive-actors/src/main/protobuf/MaterializerActor.proto
+++ b/ts-reaktive-actors/src/main/protobuf/MaterializerActor.proto
@@ -1,0 +1,23 @@
+package MaterializerActor;
+
+option java_package = "com.tradeshift.reaktive.protobuf";
+
+import "Types.proto";
+
+message MaterializerActorEvent {
+    // Ordered sequence of where each worker is. Once a worker goes past the timestamp of the next worker, it stops.
+    // Once the last worker catches up with real time, it either stalls and waits for further events (if the stream supports it)
+    // or rolls back and polls after a small delay.
+    repeated Worker worker = 1;
+
+    message Worker {
+        optional Types.UUID id = 1;
+
+        // The timestamp (inclusive) at which the worker should be re-started if it's not currently running
+        optional uint64 timestamp = 2;
+
+        // The timestamp (exclusive) at which the worker can stop working, since it's assumed events from there
+        // were already picked up by another worker.
+        optional uint64 endTimestamp = 3;
+    }
+}

--- a/ts-reaktive-actors/src/main/resources/reference.conf
+++ b/ts-reaktive-actors/src/main/resources/reference.conf
@@ -32,6 +32,9 @@ ts-reaktive {
       # How often to repeat logging the offset (latency) of the stream into metrics.
       # We repeat this in order to keep updating the offset figure, even if no metrics are received.
       update-offset-interval = 1 minute
+
+      # The maximum number of concurrent workers to start as a result of CreateWorker messages.
+      max-worker-count = 4
     }
 
     singleton {

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerActorSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerActorSpec.java
@@ -1,0 +1,166 @@
+package com.tradeshift.reaktive.materialize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.cuppa.Cuppa.beforeEach;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+import static org.forgerock.cuppa.Cuppa.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import com.tradeshift.reaktive.materialize.MaterializerActor.CreateWorker;
+import com.tradeshift.reaktive.testkit.SharedActorSystemSpec;
+import com.typesafe.config.ConfigFactory;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.stream.javadsl.Source;
+import akka.testkit.javadsl.TestKit;
+import io.vavr.collection.HashSet;
+import io.vavr.collection.Set;
+import io.vavr.collection.Stream;
+import io.vavr.collection.Vector;
+
+@RunWith(CuppaRunner.class)
+public class MaterializerActorSpec extends SharedActorSystemSpec {
+    public MaterializerActorSpec() {
+        super(ConfigFactory.parseString("ts-reaktive.actors.materializer.batch-size = 256"));
+    }
+
+    private final int N = 100; // number of events to test with
+
+    private TestKit materialized;
+
+    /** Asserts that we receive the given events, in any order, while permitting duplicates. */
+    private void assertReceiveOutOfOrder(Iterable<Envelope> events) {
+        long timeout = System.currentTimeMillis() + 5000;
+
+        Set<Envelope> received = HashSet.empty();
+        while (System.currentTimeMillis() < timeout && !received.containsAll(events)) {
+            received = received.add(materialized.expectMsgClass(Envelope.class));
+        }
+
+        assertThat(received).containsOnlyElementsOf(events);
+    }
+
+    {
+        describe("MaterializerActor", () -> {
+            beforeEach(() -> {
+                materialized = new TestKit(system);
+            });
+
+            when("importing events for the same entity", () -> {
+                Vector<Envelope> events = Stream.range(0, N).map(i ->
+                    new Envelope(Instant.ofEpochMilli(1000000 + i * 1000), "entity", i)
+                ).toVector();
+
+                it("runs sequentially when using a single worker", () -> {
+                    ActorRef actor = system.actorOf(Props.create(TestActor.class, () ->
+                        new TestActor(Source.from(events), materialized.getRef())));
+
+                    events.forEach(materialized::expectMsgEquals);
+
+                    system.stop(actor);
+                });
+
+                it("runs concurrently if a second worker is started", () -> {
+                    ActorRef actor = system.actorOf(Props.create(TestActor.class, () ->
+                        new TestActor(Source.from(events), materialized.getRef())));
+                    actor.tell(new CreateWorker(Instant.ofEpochMilli(1000000 + (N/2) * 1000)), system.deadLetters());
+
+                    assertReceiveOutOfOrder(events);
+
+                    system.stop(actor);
+                });
+            });
+
+
+            when("importing events for different entities", () -> {
+                Vector<Envelope> events = Stream.range(0, 100).map(i ->
+                    new Envelope(Instant.ofEpochMilli(1000000 + i * 1000), "entity" + i, i)
+                ).toVector();
+
+                it("runs concurrently", () -> {
+                    ActorRef actor = system.actorOf(Props.create(TestActor.class, () ->
+                        new TestActor(Source.from(events), materialized.getRef())));
+
+                    assertReceiveOutOfOrder(events);
+
+                    system.stop(actor);
+                });
+            });
+        });
+    }
+
+    static class Envelope {
+        private final Instant timestamp;
+        private final String entityId;
+        private final int index;
+
+        public Envelope(Instant timestamp, String entityId, int index) {
+            this.timestamp = timestamp;
+            this.entityId = entityId;
+            this.index = index;
+        }
+
+        @Override
+        public boolean equals(Object b) {
+            Envelope e = (Envelope) b;
+            return e.timestamp.equals(timestamp) && e.entityId.equals(entityId) && e.index == index;
+        }
+
+        @Override
+        public int hashCode() {
+            return timestamp.hashCode() ^ entityId.hashCode() ^ index;
+        }
+
+        @Override
+        public String toString() {
+            return entityId + "  at " + timestamp + ": " + index;
+        }
+    }
+
+    static class TestActor extends MaterializerActor<Envelope> {
+        private final Source<Envelope,NotUsed> events;
+        private final ActorRef materialized;
+
+        public TestActor(Source<Envelope,NotUsed> events, ActorRef materialized) {
+            this.events = events;
+            this.materialized = materialized;
+        }
+
+        @Override
+        protected CompletionStage<Done> materialize(Envelope envelope) {
+            CompletableFuture<Done> f = new CompletableFuture<>();
+            getContext().getSystem().scheduler().scheduleOnce(Duration.ofMillis(10), () -> {
+                materialized.tell(envelope, self());
+                f.complete(Done.getInstance());
+            }, getContext().dispatcher());
+            return f;
+        }
+
+        @Override
+        protected String getEntityId(Envelope envelope) {
+            return envelope.entityId;
+        }
+
+        @Override
+        protected Source<Envelope, NotUsed> loadEvents(Instant since) {
+            return events.dropWhile(e -> e.timestamp.isBefore(since));
+        }
+
+        @Override
+        public Instant timestampOf(Envelope envelope) {
+            return envelope.timestamp;
+        }
+
+    }
+}

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerWorkersSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerWorkersSpec.java
@@ -1,0 +1,130 @@
+package com.tradeshift.reaktive.materialize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+
+@RunWith(CuppaRunner.class)
+public class MaterializerWorkersSpec {
+    {
+        describe("empty MaterializerWorkers", () -> {
+            MaterializerWorkers w = MaterializerWorkers.empty(Duration.ofSeconds(6));
+
+            it("should start a new worker and not give it an end timestamp", () -> {
+                MaterializerWorkers result = w.applyEvent(w.startWorker(Instant.EPOCH));
+                assertThat(result.getIds()).hasSize(1);
+
+                UUID id = result.getIds().head();
+                assertThat(result.getTimestamp(id)).isEqualTo(Instant.EPOCH);
+                assertThat(result.getEndTimestamp(id)).isEmpty();
+            });
+        });
+
+        describe("MaterializerWorkers with 1 worker", () -> {
+            MaterializerWorkers w = MaterializerWorkers.build(Duration.ofSeconds(6),
+                i -> i.startWorker(Instant.ofEpochMilli(1000000)));
+            UUID worker1 = w.getIds().head();
+
+            it("should record progress of its worker", () -> {
+                MaterializerWorkers result = w.applyEvent(w.onWorkerProgress(worker1, Instant.ofEpochMilli(1500000)));
+
+                assertThat(result.getTimestamp(worker1)).isEqualTo(Instant.ofEpochMilli(1500001));
+                assertThat(result.getEndTimestamp(worker1)).isEmpty();
+            });
+
+            it("should start a new worker BEFORE the existing timestamp", () -> {
+                MaterializerWorkers result = w.applyEvent(w.startWorker(Instant.EPOCH));
+                assertThat(result.getIds()).hasSize(2);
+
+                UUID worker2 = result.getIds().head();
+                assertThat(worker2).isNotEqualTo(worker1);
+                assertThat(result.getTimestamp(worker2)).isEqualTo(Instant.EPOCH);
+                assertThat(result.getEndTimestamp(worker2)).contains(Instant.ofEpochMilli(1000000));
+
+                assertThat(result.getTimestamp(worker1)).isEqualTo(Instant.ofEpochMilli(1000000));
+                assertThat(result.getEndTimestamp(worker1)).isEmpty();
+            });
+
+            it("should start a new worker AFTER the existing timestamp", () -> {
+                MaterializerWorkers result = w.applyEvent(w.startWorker(Instant.ofEpochMilli(2000000)));
+                assertThat(result.getIds()).hasSize(2);
+
+                UUID worker2 = result.getIds().last();
+                assertThat(worker2).isNotEqualTo(worker1);
+                assertThat(result.getTimestamp(worker2)).isEqualTo(Instant.ofEpochMilli(2000000));
+                assertThat(result.getEndTimestamp(worker2)).isEmpty();
+
+                assertThat(result.getTimestamp(worker1)).isEqualTo(Instant.ofEpochMilli(1000000));
+                assertThat(result.getEndTimestamp(worker1)).contains(Instant.ofEpochMilli(2000000));
+            });
+
+            it("should not start a new worker close to the existing timestamp", () -> {
+                MaterializerWorkers result = w.applyEvent(w.startWorker(Instant.ofEpochMilli(1000002)));
+                assertThat(result.getIds()).containsExactly(worker1);
+                assertThat(result.getTimestamp(worker1)).isEqualTo(Instant.ofEpochMilli(1000000));
+            });
+        });
+
+        describe("MaterializerWorkers with 2 workers and a hole between them", () -> {
+            MaterializerWorkers w = MaterializerWorkers.build(Duration.ofSeconds(6),
+                i -> i.startWorker(Instant.ofEpochMilli(1000000)),
+                i -> i.startWorker(Instant.ofEpochMilli(2000000)),
+
+                // create a third worker between 1 and 2, and complete it immediately. That will create a hole.
+                i -> i.startWorker(Instant.ofEpochMilli(1500000)),
+                i -> i.onWorkerProgress(i.getIds().apply(1), Instant.ofEpochMilli(2000000)));
+
+            UUID worker1 = w.getIds().apply(0);
+            UUID worker2 = w.getIds().apply(1);
+
+            it("should have a hole start out with", () -> {
+                assertThat(w.getEndTimestamp(worker1)).contains(Instant.ofEpochMilli(1500000));
+                assertThat(w.getTimestamp(worker2)).isEqualTo(Instant.ofEpochMilli(2000000));
+            });
+
+            it("should stop worker 1 once it catches up with its end timestamp", () -> {
+                MaterializerWorkers result = w.applyEvent(w.onWorkerProgress(worker1, Instant.ofEpochMilli(1500000)));
+
+                assertThat(result.getIds()).containsOnly(worker2);
+                assertThat(result.getTimestamp(worker2)).isEqualTo(Instant.ofEpochMilli(2000000));
+            });
+
+            it("should start a worker between worker 1's end and worker 2's start", () -> {
+                MaterializerWorkers result = w.applyEvent(w.startWorker(Instant.ofEpochMilli(1700000)));
+                assertThat(result.getIds()).hasSize(3);
+
+                UUID worker3 = result.getIds().apply(1);
+                assertThat(worker3).isNotEqualTo(worker1).isNotEqualTo(worker2);
+                assertThat(result.getTimestamp(worker3)).isEqualTo(Instant.ofEpochMilli(1700000));
+                assertThat(result.getEndTimestamp(worker3)).contains(Instant.ofEpochMilli(2000000));
+
+                // worker 1 should be unaffected, because the new worker is started in the hole
+                assertThat(result.getTimestamp(worker1)).isEqualTo(Instant.ofEpochMilli(1000000));
+                assertThat(result.getEndTimestamp(worker1)).contains(Instant.ofEpochMilli(1500000));
+            });
+
+            it("should start a worker between worker 1's start and end", () -> {
+                MaterializerWorkers result = w.applyEvent(w.startWorker(Instant.ofEpochMilli(1200000)));
+                assertThat(result.getIds()).hasSize(3);
+
+                UUID worker3 = result.getIds().apply(1);
+                assertThat(worker3).isNotEqualTo(worker1).isNotEqualTo(worker2);
+                assertThat(result.getTimestamp(worker3)).isEqualTo(Instant.ofEpochMilli(1200000));
+                // New worker should end where worker1 would have ended, since it effectively split worker1 in half.
+                assertThat(result.getEndTimestamp(worker3)).contains(Instant.ofEpochMilli(1500000));
+
+                // Worker1 now only needs to run until where the new worker started.
+                assertThat(result.getTimestamp(worker1)).isEqualTo(Instant.ofEpochMilli(1000000));
+                assertThat(result.getEndTimestamp(worker1)).contains(Instant.ofEpochMilli(1200000));
+            });
+        });
+
+    }
+}


### PR DESCRIPTION
The materializer now can run multiple worker streams in parallel, with
each stream having its own end timestamp to start processing. This
allows large event journals to prioritize importing recent events, while
still allowing all historic events to be read as well.