### PR TITLE
Allow endTimestamp for new workers, and add query API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,7 @@ lazy val commonSettings = projectSettings ++ Seq(
       "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
       "com.typesafe.akka" %% "akka-http-jackson" % akkaHttpVersion,
       "com.typesafe.akka" %% "akka-persistence-cassandra" % "0.83",
+      "org.quicktheories" % "quicktheories" % "0.26" % "test",
       "org.slf4j" % "slf4j-log4j12" % "1.7.12"
     )
   }  

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerActor.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerActor.java
@@ -110,9 +110,9 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
             .match(Reimport.class, msg -> {
                 reimport(msg.entityIds);
             })
-            .match(QueryReimport.class, msg -> {
-                Instant progress = reimportProgress.get();
-                sender().tell(progress != null ? progress : Done.getInstance(), self());
+            .match(QueryProgress.class, msg -> {
+                Option<Instant> reimportP = Option.of(reimportProgress.get());
+                sender().tell(new Progress(reimportP, workers), self());
             })
             .matchEquals("reimportComplete", msg -> {
                 log.info("Re-import completed.");
@@ -123,7 +123,7 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
                 materializeEvents(msg.worker);
             })
             .match(CreateWorker.class, msg -> {
-                createWorker(msg.timestamp);
+                createWorker(msg.timestamp, msg.endTimestamp);
             })
             .matchEquals("init", msg -> getSender().tell("ack", self()))
             .match(WorkerProgress.class, p -> {
@@ -160,14 +160,14 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
             .build();
     }
 
-    private void createWorker(Instant timestamp) {
+    private void createWorker(Instant timestamp, Option<Instant> endTimestamp) {
         if (workers.getIds().size() >= maxWorkerCount) {
             log.warning("Ignoring request to start extra worker at {}, because maximum of {} is already reached.",
                 timestamp, workers.getIds().size());
             return;
         }
 
-        persist(workers.startWorker(timestamp), evt -> {
+        persist(workers.startWorker(timestamp, endTimestamp), evt -> {
             applyEvent(evt);
 
             // Start the new worker:
@@ -429,19 +429,71 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
     }
 
     /**
-     * Message that can be sent to this actor to query the progress of any on-going reimport.
-     * It returns an Instant with the last-reimported timestamp, or Done if no import is in progress.
+     * Message that can be sent to this actor to query its current progress.
+     *
+     * A Progress message will be sent back.
      */
-    public static class QueryReimport implements Serializable {
+    public static class QueryProgress implements Serializable {
         private static final long serialVersionUID = 1L;
 
-        public static final QueryReimport instance = new QueryReimport();
-        private QueryReimport() {}
+        public static final QueryProgress instance = new QueryProgress();
+        private QueryProgress() {}
+    }
+
+    public static class Progress implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final Option<Instant> reimportTimestamp;
+        private final Seq<ProgressWorker> workers;
+
+        private Progress(Option<Instant> reimportTimestamp, MaterializerWorkers state) {
+            this.reimportTimestamp = reimportTimestamp;
+            this.workers = state.getIds().map(id ->
+                new ProgressWorker(id, state.getTimestamp(id), state.getEndTimestamp(id)));
+        }
+
+        public Option<Instant> getReimportTimestamp() {
+            return reimportTimestamp;
+        }
+
+        public Seq<ProgressWorker> getWorkers() {
+            return workers;
+        }
+    }
+
+    public static class ProgressWorker implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final UUID id;
+        private final Instant timestamp;
+        private final Option<Instant> endTimestamp;
+
+        public ProgressWorker(UUID id, Instant timestamp, Option<Instant> endTimestamp) {
+            this.id = id;
+            this.timestamp = timestamp;
+            this.endTimestamp = endTimestamp;
+        }
+
+        public UUID getId() {
+            return id;
+        }
+
+        public Instant getTimestamp() {
+            return timestamp;
+        }
+
+        public Option<Instant> getEndTimestamp() {
+            return endTimestamp;
+        }
     }
 
     /**
      * Message that can be sent to this actor to have it launch an extra worker, which starts
-     * work at the given timestamp.
+     * work at the given timestamp, and works at most to the given endTimestamp (if given).
+     *
+     * endTimestamp is only used if this would create a worker starting BEFORE all other workers,
+     * and even then will only be allowing the new worker to stop EARLIER than the currently earliest
+     * worker.
      *
      * If the maximum number of workers has been reached, or if the timestamp is too close to an
      * existing worker, the request is ignored.
@@ -450,9 +502,16 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
         private static final long serialVersionUID = 1L;
 
         private final Instant timestamp;
+        private final Option<Instant> endTimestamp;
 
-        public CreateWorker(Instant timestamp) {
+        public CreateWorker(Instant timestamp, Option<Instant> endTimestamp) {
             this.timestamp = timestamp;
+            this.endTimestamp = endTimestamp;
+            for (Instant end: endTimestamp) {
+                if (!timestamp.isBefore(end)) {
+                    throw new IllegalArgumentException("endTimestamp must be after timestamp if given");
+                }
+            }
         }
     }
 

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerActor.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerActor.java
@@ -193,6 +193,7 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
                 if (workers.isEmpty()) {
                     workers = workers.initialize();
                 }
+                log.info("Recovery completed, workers: {}", workers);
                 workers.getIds().forEach(this::materializeEvents);
             })
             .build();
@@ -490,10 +491,6 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
     /**
      * Message that can be sent to this actor to have it launch an extra worker, which starts
      * work at the given timestamp, and works at most to the given endTimestamp (if given).
-     *
-     * endTimestamp is only used if this would create a worker starting BEFORE all other workers,
-     * and even then will only be allowing the new worker to stop EARLIER than the currently earliest
-     * worker.
      *
      * If the maximum number of workers has been reached, or if the timestamp is too close to an
      * existing worker, the request is ignored.

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerWorkers.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerWorkers.java
@@ -3,9 +3,12 @@ package com.tradeshift.reaktive.materialize;
 import static com.tradeshift.reaktive.protobuf.UUIDs.toJava;
 import static com.tradeshift.reaktive.protobuf.UUIDs.toProtobuf;
 
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import com.tradeshift.reaktive.protobuf.MaterializerActor.MaterializerActorEvent;
@@ -37,7 +40,12 @@ public class MaterializerWorkers {
     private final Seq<Worker> workers;
     private final TemporalAmount rollback;
 
-    private MaterializerWorkers(Seq<Worker> workers, TemporalAmount rollback) {
+    /**
+     * Creates a new MaterializerWorkers.
+     *
+     * This constructor is package-private so we can instantiate it directly in unit tests.
+     */
+    MaterializerWorkers(Seq<Worker> workers, TemporalAmount rollback) {
         this.workers = workers;
         this.rollback = rollback;
     }
@@ -86,6 +94,7 @@ public class MaterializerWorkers {
      * @return An event to emit with the new restart indexes. In case the worker was done, it will
      * be absent from the emitted event.
      */
+    // FIXME inject Now() into this as a parameter
     public MaterializerActorEvent onWorkerProgress(UUID workerId, Instant timestamp) {
         int index = workers.map(Worker::getId).indexOf(toProtobuf(workerId));
         if (index == -1) {
@@ -93,9 +102,10 @@ public class MaterializerWorkers {
         }
         Worker worker = workers.apply(index);
         if (worker.hasEndTimestamp() && timestamp.toEpochMilli() >= worker.getEndTimestamp()) {
-            return MaterializerActorEvent.newBuilder()
-                .addAllWorker(workers.removeAt(index))
-                .build();
+            return toEvent(workers.removeAt(index));
+        } else if (timestamp.toEpochMilli() <= worker.getTimestamp()) {
+            // New timestamp is in the past -> ignore it
+            return unchanged();
         } else {
             // We're now positively done with timestamp [o].
             // If [o] is long enough ago, we can start with [o+1] next time. Otherwise, we start again at now() minus rollback.
@@ -107,11 +117,20 @@ public class MaterializerWorkers {
                 newTimestamp = now.minus(rollback).toEpochMilli();
             }
 
+            if (index < workers.size() - 1 && newTimestamp >= workers.apply(index + 1).getTimestamp()) {
+                // We're done after all, since we're beyond the next worker's start timestamp
+                return toEvent(workers.removeAt(index));
+            }
+
             return toEvent(workers.update(index, worker.toBuilder()
                 .setTimestamp(newTimestamp)
                 .build()
             ));
         }
+    }
+
+    private MaterializerActorEvent unchanged() {
+        return toEvent(workers);
     }
 
     private static MaterializerActorEvent toEvent(Seq<Worker> workers) {
@@ -121,8 +140,7 @@ public class MaterializerWorkers {
     /**
      * Attempts to start a new worker which should start at the given start timestamp.
      *
-     * If the start timestamp is close to another worker's timestamp, no worker is started since
-     * that would be non-sensical.
+     * If the start timestamp is equal to another worker's timestamp, no worker is started.
      *
      * @return An event to emit with new restart indexes.
      */
@@ -136,27 +154,27 @@ public class MaterializerWorkers {
             ));
         }
 
-        if (workers.exists(w -> Math.abs(w.getTimestamp() - t) < 1000)) {
+        if (workers.exists(w -> w.getTimestamp() == t)) {
             // Start timestamp too close to an existing worker, so don't start a new one.
-            return toEvent(workers);
+            return unchanged();
+        }
+
+        if (endTimestamp.exists(e -> e.toEpochMilli() < t)) {
+            // endTimestamp is before start -> don't start this worker
+            return unchanged();
         }
 
         int index = workers.indexWhere(w -> w.getTimestamp() >= t);
         if (index == 0) {
             // Prepend to beginning, run to timestamp of current first worker
-            if (endTimestamp.exists(e -> e.toEpochMilli() <= t)) {
-                // endTimestamp is equal to or before start -> don't start this worker
-                return toEvent(workers);
-            } else {
-                return toEvent(workers
-                    .insert(0, Worker.newBuilder()
-                        .setId(toProtobuf(UUID.randomUUID()))
-                        .setTimestamp(t)
-                        .setEndTimestamp(earliest(workers.head().getTimestamp(), endTimestamp))
-                        .build()
-                    )
-                );
-            }
+            return toEvent(workers
+                .insert(0, Worker.newBuilder()
+                    .setId(toProtobuf(UUID.randomUUID()))
+                    .setTimestamp(t)
+                    .setEndTimestamp(earliest(workers.head().getTimestamp(), endTimestamp))
+                    .build()
+                )
+            );
         } else if (index == -1) {
             // Append to end, make currently last worker only run until the timestamp we start at
             return toEvent(workers
@@ -192,7 +210,7 @@ public class MaterializerWorkers {
                     .insert(index, Worker.newBuilder()
                         .setId(toProtobuf(UUID.randomUUID()))
                         .setTimestamp(t)
-                        .setEndTimestamp(workers.apply(index).getTimestamp())
+                        .setEndTimestamp(earliest(workers.apply(index).getTimestamp(), endTimestamp))
                         .build()
                     )
                 );

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/Generators.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/Generators.java
@@ -1,0 +1,86 @@
+package com.tradeshift.reaktive.materialize;
+
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.SourceDSL.*;
+import static org.quicktheories.generators.Generate.constant;
+
+import static com.tradeshift.reaktive.protobuf.UUIDs.toProtobuf;
+import com.tradeshift.reaktive.protobuf.MaterializerActor.MaterializerActorEvent.Worker;
+
+import org.quicktheories.core.Gen;
+
+import io.vavr.Tuple;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Vector;
+import io.vavr.control.Option;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAmount;
+import java.util.UUID;
+
+public class Generators {
+    public static Gen<MaterializerWorkers> materializerWorkers() {
+        return integers().from(0).upTo(5).flatMap(count -> materializerWorkers(count, 10));
+    }
+
+    public static Gen<MaterializerWorkers> materializerWorkersNonEmpty() {
+        return integers().from(1).upTo(5).flatMap(count -> materializerWorkers(count, 10));
+    }
+
+    public static Gen<MaterializerWorkers> materializerWorkersLong() {
+        return integers().from(1).upTo(5).flatMap(count -> materializerWorkers(count, 99));
+    }
+
+    public static Gen<MaterializerWorkers> materializerWorkers(int count, int longWorkerLikelihood) {
+        Gen<Integer> gap = integers().from(0).upTo(1000);
+        Gen<Integer> work = integers().from(100).upTo(1000).mix(integers().from(100).upTo(1000), longWorkerLikelihood);
+
+        Gen<Seq<Worker>> workersSeq = lists().of(
+            work.zip(gap, Tuple::of)
+        ).ofSize(count).map(list -> Vector.ofAll(list)).map(data -> {
+
+            Vector<Worker> workers = Vector.empty();
+
+            Vector<Integer> startTimes = data.scanLeft(0, (time, tuple) -> (time + tuple._1 + tuple._2));
+            Vector<Integer> endTimes = startTimes.zip(data.map(t -> t._1)).map(t -> t._1 + t._2);
+
+            // All workers except the last one have an end timestamp
+            for (int i = 0; i < data.size() - 1; i++) {
+                if (endTimes.apply(i) <= startTimes.apply(i)) {
+                    throw new IllegalStateException("huh " + startTimes + " / " + endTimes);
+                }
+                workers = workers.append(Worker.newBuilder()
+                    .setId(toProtobuf(workerId(i)))
+                    .setTimestamp(startTimes.apply(i))
+                    .setEndTimestamp(endTimes.apply(i))
+                    .build());
+            }
+
+            // The last one always has no timestamp
+            if (data.size() > 0) {
+                int i = data.size() - 1;
+                workers = workers.append(Worker.newBuilder()
+                    .setId(toProtobuf(workerId(i)))
+                    .setTimestamp(startTimes.apply(i))
+                    .build());
+            }
+
+            return workers;
+        });
+
+        Gen<TemporalAmount> rollbacks = integers().from(0).upTo(1000).map(i -> Duration.of(i, ChronoUnit.SECONDS));
+
+        return workersSeq.zip(rollbacks, MaterializerWorkers::new);
+    }
+
+    public static <T> Gen<Option<T>> option(Gen<T> gen) {
+        return booleans().all().flatMap(present -> present ? gen.map(Option::some) : constant(Option.none()));
+    }
+
+    // Worker UUIDs can't be random, since quickTheories will put in silly and duplicate UUIDs.
+    private static UUID workerId(int index) {
+        UUID workerIdBase = UUID.fromString("35c2ae01-b26e-49ad-8fd1-000000000000");
+        return new UUID(workerIdBase.getMostSignificantBits(), workerIdBase.getLeastSignificantBits() + index);
+    }
+}

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerActorSpec.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerActorSpec.java
@@ -28,6 +28,7 @@ import io.vavr.collection.HashSet;
 import io.vavr.collection.Set;
 import io.vavr.collection.Stream;
 import io.vavr.collection.Vector;
+import static io.vavr.control.Option.none;
 
 @RunWith(CuppaRunner.class)
 public class MaterializerActorSpec extends SharedActorSystemSpec {
@@ -74,7 +75,7 @@ public class MaterializerActorSpec extends SharedActorSystemSpec {
                 it("runs concurrently if a second worker is started", () -> {
                     ActorRef actor = system.actorOf(Props.create(TestActor.class, () ->
                         new TestActor(Source.from(events), materialized.getRef())));
-                    actor.tell(new CreateWorker(Instant.ofEpochMilli(1000000 + (N/2) * 1000)), system.deadLetters());
+                    actor.tell(new CreateWorker(Instant.ofEpochMilli(1000000 + (N/2) * 1000), none()), system.deadLetters());
 
                     assertReceiveOutOfOrder(events);
 

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerWorkersTheories.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerWorkersTheories.java
@@ -1,0 +1,162 @@
+package com.tradeshift.reaktive.materialize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.cuppa.Cuppa.describe;
+import static org.forgerock.cuppa.Cuppa.it;
+import static org.quicktheories.QuickTheory.qt;
+import static org.quicktheories.generators.Generate.constant;
+import static org.quicktheories.generators.SourceDSL.integers;
+import static org.quicktheories.generators.SourceDSL.longs;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import com.tradeshift.reaktive.protobuf.MaterializerActor.MaterializerActorEvent;
+import com.tradeshift.reaktive.protobuf.MaterializerActor.MaterializerActorEvent.Worker;
+import com.tradeshift.reaktive.protobuf.UUIDs;
+
+import org.assertj.core.api.Condition;
+import org.forgerock.cuppa.junit.CuppaRunner;
+import org.junit.runner.RunWith;
+import org.quicktheories.core.Gen;
+
+import io.vavr.Tuple;
+import io.vavr.Tuple2;
+import io.vavr.Tuple3;
+import io.vavr.control.Option;
+
+@RunWith(CuppaRunner.class)
+public class MaterializerWorkersTheories {
+    {
+        describe("MaterializerWorkers.initialize()", () -> {
+            it("should always return at least one worker", () -> {
+                qt()
+                    .forAll(Generators.materializerWorkers())
+                    .checkAssert(w -> {
+                        MaterializerWorkers i = w.initialize();
+                        assertSane(i);
+                        assertThat(i.getIds()).isNotEmpty();
+                    });
+            });
+
+            it("should not create new workers if workers are already present", () -> {
+                qt()
+                    .forAll(Generators.materializerWorkersNonEmpty())
+                    .checkAssert(w -> {
+                        MaterializerWorkers i = w.initialize();
+                        assertSane(i);
+                        assertThat(i.getIds()).hasSameElementsAs(w.getIds());
+                    });
+            });
+        });
+
+        describe("MaterializerWorkers.onWorkerProgress()", () -> {
+            it("should stop the worker if needed, and produce sane results", () -> {
+                qt()
+                    .forAll(Generators.materializerWorkersNonEmpty()
+                        .flatMap(w -> constant(w).zip(
+                            integers().from(0).upTo(w.getIds().size()),
+                            startTimestamps(w),
+                            Tuple::of)
+                        )
+                    )
+                    .checkAssert(t -> {
+                        MaterializerActorEvent event = t._1.onWorkerProgress(t._1.getIds().apply(t._2), t._3);
+                        assertThat(event.getWorkerList()).extracting(w -> UUIDs.toJava(w.getId())).isSubsetOf(t._1.getIds());
+                        assertThat(event.getWorkerList().size()).isGreaterThanOrEqualTo(t._1.getIds().size() - 1);
+
+                        MaterializerWorkers p = t._1.applyEvent(event);
+                        assertSane(p);
+                    });
+            });
+        });
+
+        describe("MaterializerWorkers.startWorker()", () -> {
+            it("should start a worker if needed, and produce sane results", () -> {
+                qt()
+                    .forAll(Generators.materializerWorkersNonEmpty()
+                        .flatMap(w -> constant(w).zip(
+                            startTimestamps(w),
+                            Generators.option(startTimestamps(w)),
+                            Tuple::of)
+                        )
+                    )
+                    .checkAssert(t -> {
+                        MaterializerActorEvent event = t._1.startWorker(t._2, t._3);
+                        assertThat(event.getWorkerList()).extracting(w -> UUIDs.toJava(w.getId())).containsAll(t._1.getIds());
+                        assertThat(event.getWorkerList().size()).isGreaterThanOrEqualTo(t._1.getIds().size());
+
+                        MaterializerWorkers p = t._1.applyEvent(event);
+                        assertSane(p);
+
+                        // Applying the same start and end shouldn't create any new workers
+                        assertThat(p.startWorker(t._2, t._3)).isEqualTo(event);
+                    });
+            });
+
+            it("should start a new worker if given a timestamp unequal to existing timestamps", () -> {
+                qt()
+                    .forAll(Generators.materializerWorkersLong()
+                        .flatMap(w ->
+                            startAndEndTimestamps(w).map(t -> Tuple.of(w, t._1, t._2))
+                        )
+                    )
+                    .assuming(t ->
+                        t._1.getIds().map(t._1::getTimestamp).forAll(
+                            time -> time.toEpochMilli() != t._2.toEpochMilli()
+                        )
+                    )
+                    .checkAssert(t -> {
+                        MaterializerActorEvent event = t._1.startWorker(t._2, Option.some(t._3));
+                        assertThat(event.getWorkerList().size()).isGreaterThan(t._1.getIds().size());
+                        assertThat(event.getWorkerList()).haveAtLeastOne(workerForTime(t._2));
+                    });
+            });
+        });
+    }
+
+    private Condition<Worker> workerForTime(Instant time) {
+        long t = time.toEpochMilli();
+        return new Condition<Worker>(w ->
+            w.getTimestamp() <= t && (!w.hasEndTimestamp() || w.getEndTimestamp() >= t)
+        , "Contains time " + time);
+    }
+
+    private Gen<Instant> startTimestamps(MaterializerWorkers w) {
+        return integers().from(0).upTo(w.getIds().size()).zip(longs().from(-100).upTo(100), (idx, ofs) ->
+            atLeastEpoch(w.getTimestamp(w.getIds().apply(idx)).plusMillis(ofs))
+        );
+    }
+
+    private Instant atLeastEpoch(Instant i) {
+        return i.isBefore(Instant.EPOCH) ? Instant.EPOCH : i;
+    }
+
+    private Gen<Tuple2<Instant,Instant>> startAndEndTimestamps(MaterializerWorkers w) {
+        return integers().from(0).upTo(w.getIds().size())
+            .zip(longs().from(-5).upTo(100), longs().from(1).upTo(1000), (idx, ofs, dur) -> {
+                Instant start = atLeastEpoch(w.getTimestamp(w.getIds().apply(idx)).plusMillis(ofs));
+                return Tuple.of(start, start.plusMillis(dur));
+            });
+
+    }
+
+    private static void assertSane(MaterializerWorkers w) {
+        if (w.getIds().isEmpty()) {
+            return;
+        };
+
+        assertThat(w.getEndTimestamp(w.getIds().last())).isEmpty();
+
+        for (int i = 1; i < w.getIds().size(); i++) {
+            UUID a = w.getIds().apply(i - 1);
+            UUID b = w.getIds().apply(i);
+
+            assertThat(w.getEndTimestamp(a)).describedAs("End rimestamp of " + a + " in:\n" + w).isNotEmpty();
+            assertThat(w.getEndTimestamp(a).get()).describedAs("End timestamp of " + a + " in:\n" + w).isGreaterThanOrEqualTo(w.getTimestamp(a));
+            assertThat(w.getTimestamp(a)).describedAs("Timestamp of " + a + " in:\n" + w).isLessThan(w.getTimestamp(b));
+            assertThat(w.getEndTimestamp(a).get()).describedAs("End timestamp of " + a + " in:\n" + w).isLessThanOrEqualTo(w.getTimestamp(b));
+        }
+    }
+}


### PR DESCRIPTION
Specifying an endTimestamp is handy when not everything before the first
worker needs to be reindexed.

The query API can be used to keep an eye on workers' progress, and react
when workers complete.