### PR TITLE
Update kamon stats for multiple workers, and implement reset

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerMetrics.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerMetrics.java
@@ -5,41 +5,56 @@ import java.util.Map;
 import io.vavr.collection.HashMap;
 import kamon.Kamon;
 import kamon.metric.Counter;
-import kamon.metric.Histogram;
-import kamon.metric.HistogramMetric;
+import kamon.metric.CounterMetric;
+import kamon.metric.Gauge;
+import kamon.metric.GaugeMetric;
 import kamon.metric.MeasurementUnit;
 
 public class MaterializerMetrics {
     private final HashMap<String, String> baseTags;
-    private final Counter events;
+    private final CounterMetric events;
     private final Counter restarts;
-    private final Histogram reimportRemaining;
-    private final HistogramMetric offset;
+    private final Gauge reimportRemaining;
+    /** The current timestamp for each worker, in milliseconds since the epoch */
+    private final GaugeMetric offset;
+    /** The delay between the timestamp of each worker and now(), in milliseconds */
+    private final GaugeMetric delay;
+    /** The rime remaining for each worker, in milliseconds (if there is an end timestamp) */
+    private final GaugeMetric remaining;
 
     public MaterializerMetrics(String name) {
         baseTags = HashMap.of("journal-materializer", name);
         Map<String, String> tags = baseTags.toJavaMap();
-        this.events = Kamon.counter("journal-materializer.events").refine(tags);
+        this.events = Kamon.counter("journal-materializer.events");
         this.restarts = Kamon.counter("journal-materializer.restarts").refine(tags);
-        this.reimportRemaining = Kamon.histogram("journal-materializer.reimport-remaining", MeasurementUnit.time().milliseconds()).refine(tags);
-        this.offset = Kamon.histogram("journal-materializer.offset",
-            MeasurementUnit.time().milliseconds());
+        this.reimportRemaining = Kamon.gauge("journal-materializer.reimport-remaining", MeasurementUnit.time().milliseconds()).refine(tags);
+        this.offset = Kamon.gauge("journal-materializer.offset", MeasurementUnit.time().milliseconds());
+        this.delay = Kamon.gauge("journal-materializer.delay", MeasurementUnit.time().milliseconds());
+        this.remaining = Kamon.gauge("journal-materializer.remaining", MeasurementUnit.time().milliseconds());
     }
 
 
-    public Counter getEvents() {
-        return events;
+    public Counter getEvents(int index) {
+        return events.refine(baseTags.put("index", String.valueOf(index)).toJavaMap());
     }
 
     public Counter getRestarts() {
         return restarts;
     }
 
-    public Histogram getOffset(int index) {
+    public Gauge getOffset(int index) {
         return offset.refine(baseTags.put("index", String.valueOf(index)).toJavaMap());
     }
 
-    public Histogram getReimportRemaining() {
+    public Gauge getDelay(int index) {
+        return delay.refine(baseTags.put("index", String.valueOf(index)).toJavaMap());
+    }
+
+    public Gauge getRemaining(int index) {
+        return remaining.refine(baseTags.put("index", String.valueOf(index)).toJavaMap());
+    }
+
+    public Gauge getReimportRemaining() {
         return reimportRemaining;
     }
 }

--- a/ts-reaktive-actors/src/main/resources/reference.conf
+++ b/ts-reaktive-actors/src/main/resources/reference.conf
@@ -14,6 +14,13 @@ ts-reaktive {
       # be imported in parallel.
       batch-size = 4
 
+      # How many imported events to maximally process before saving and reporting progress.
+      # If more than this value of events occur with the same timestamp, they'll still be processed
+      # together.
+      # This used to default to max-events-per-timestamp, but is lower now to get more accurate
+      # progress report metrics into Kamon.
+      update-size = 256
+
       # Delay before restarting the event stream to the backend if it completes or fails
       restart-delay = 10 seconds
 

--- a/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerWorkersTheories.java
+++ b/ts-reaktive-actors/src/test/java/com/tradeshift/reaktive/materialize/MaterializerWorkersTheories.java
@@ -114,6 +114,28 @@ public class MaterializerWorkersTheories {
                     });
             });
         });
+
+        describe("MaterializerWorkers.reset()", () -> {
+            it("should never have gaps in its result", () -> {
+                qt()
+                    .forAll(Generators.materializerWorkers())
+                    .checkAssert(w -> {
+                        MaterializerActorEvent event = w.reset();
+                        for (int i = 1; i < event.getWorkerCount(); i++) {
+                            assertThat(event.getWorker(i-1).getEndTimestamp())
+                                .describedAs("Worker %d's end timestamp, in event %s", i, event)
+                                .isEqualTo(event.getWorker(i).getTimestamp());
+
+                            assertThat(event.getWorker(i).getTimestamp())
+                                .isEqualTo(w.getTimestamp(w.getIds().apply(i)).toEpochMilli());
+                        }
+
+                        MaterializerWorkers p = w.applyEvent(event);
+                        assertSane(p);
+                    });
+            });
+
+        });
     }
 
     private Condition<Worker> workerForTime(Instant time) {


### PR DESCRIPTION
The statistic type for the time-based worker stats was wrong: since it's
a slow-changing value with only 1 global value, all of those should be
"Gauge" type and not "Histogram". An additional problem is that
histograms, by default, are limited to 2.1E12 as maximum value, which is
no good for time stamps.

We also reimplement "Reset" functionality, so we can easily trigger a
complete reimport; but now, we retain any extra workers that are already
present.