### PR TITLE
Make delete messages interval configurable

### DIFF
--- a/ts-reaktive-actors/src/main/resources/reference.conf
+++ b/ts-reaktive-actors/src/main/resources/reference.conf
@@ -42,6 +42,11 @@ ts-reaktive {
 
       # The maximum number of concurrent workers to start as a result of CreateWorker messages.
       max-worker-count = 4
+
+      # How many events to emit before deleting old events.
+      # Only the latest event needs to be retained, but to some journal implementations delete is a heavy
+      # operation, so we allow this to be tweaked.
+      delete-messages-after = 25
     }
 
     singleton {


### PR DESCRIPTION
We'd hardcoded it to 25 before which is appropriate for most journals, but probably is better left being configurable.