### PR TITLE
Enable addition of custom tags to MaterializerActor metrics

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerActor.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerActor.java
@@ -61,7 +61,7 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
     protected final LoggingAdapter log = Logging.getLogger(getContext().getSystem(), this);
     private final MaterializerMetrics metrics = new MaterializerMetrics(
         // Turn CamelCase to camel-case.
-        getClass().getSimpleName().replaceAll("([a-z])([A-Z]+)", "$1-$2").toLowerCase());
+        getClass().getSimpleName().replaceAll("([a-z])([A-Z]+)", "$1-$2").toLowerCase(), getAdditionalMetricTags());
     private final FiniteDuration rollback;
     private final FiniteDuration updateAccuracy;
     private final FiniteDuration restartDelay;
@@ -433,6 +433,14 @@ public abstract class MaterializerActor<E> extends AbstractPersistentActor {
      * Get a timestamp of event envelope.
      */
     public abstract Instant timestampOf(E envelope);
+
+    /**
+     * @return the custom tags which will be attached to materializer metrics reported by Kamon.
+     * By default, only the class name is attached as a tag in Kamon metrics and there are no custom tags.
+     */
+    protected Option<HashMap<String, String>> getAdditionalMetricTags() {
+        return none();
+    }
 
     /**
      * Message that can be sent to this actor to start a secondary re-import of certain UUIDs.

--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerMetrics.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerMetrics.java
@@ -3,6 +3,7 @@ package com.tradeshift.reaktive.materialize;
 import java.util.Map;
 
 import io.vavr.collection.HashMap;
+import io.vavr.control.Option;
 import kamon.Kamon;
 import kamon.metric.Counter;
 import kamon.metric.CounterMetric;
@@ -26,8 +27,8 @@ public class MaterializerMetrics {
     /** The duration, milliseconds, of materializing a single event */
     private final HistogramMetric materializationDuration;
 
-    public MaterializerMetrics(String name) {
-        baseTags = HashMap.of("journal-materializer", name);
+    public MaterializerMetrics(String name, Option<HashMap<String, String>> additionalTags) {
+        baseTags = additionalTags.getOrElse(HashMap.empty()).put("journal-materializer", name);
         Map<String, String> tags = baseTags.toJavaMap();
         this.events = Kamon.counter("journal-materializer.events");
         this.restarts = Kamon.counter("journal-materializer.restarts").refine(tags);


### PR DESCRIPTION
The only base tag attached to all MaterializerActor metrics is the class
name of the actor. This can lead to duplicate metric names
if a single subclass is instantiated multiple times to do different
materializations. To remedy this and also facilitate further adjustments
of metric tags, this commit adds a protected method so that the
subclasses can introduce new tags to the metrics.