### PR TITLE
Allow subclasses to hold off on commands while not idle 

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/AbstractStatefulPersistentActor.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/actors/AbstractStatefulPersistentActor.java
@@ -75,6 +75,14 @@ public abstract class AbstractStatefulPersistentActor<C,E,S extends AbstractStat
         return context().system().settings().config().getDuration("ts-reaktive.actors.passivate-timeout");
     }
 
+    /**
+     * Returns whether the asynchronous part of a Handler for this command is currently in progress
+     * (and, hence, further commands would currently be stashed if sent to this actor)
+     */
+    protected boolean isCommandInProgress() {
+        return !idle;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public Receive createReceive() {
@@ -147,9 +155,6 @@ public abstract class AbstractStatefulPersistentActor<C,E,S extends AbstractStat
      * Must only be invoked if {@link #canHandleCommand(Object)} has returned true for this command.
      */
     protected void handleCommand(C cmd) {
-        // FIXME We need to uphold command ordering for the same sender (just like akka does for normal messages).
-        // Hence, we need to stash subsequent messages from the same sender, while one message from that sender is still
-        // being piped.
         pipe(handlers.handle(state, cmd), context().dispatcher()).to(self(), sender());
     }
 

--- a/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/actors/ReplicatedActor.java
+++ b/ts-reaktive-replication/src/main/java/com/tradeshift/reaktive/replication/actors/ReplicatedActor.java
@@ -154,6 +154,8 @@ public abstract class ReplicatedActor<C,E,S extends AbstractState<E,S>> extends 
                 getContext().become(master());
                 if (receive.onMessage().isDefinedAt(c)) {
                     receive.onMessage().apply(c);
+                } else {
+                    log.warning("Unhandled first write command: {}", c);
                 }
             })
             .match(Query.EventEnvelope.class, e -> {


### PR DESCRIPTION
The base AbstractStatefulPersistentActor class stashes further commands
while handling (the async part of) a command. However, subclasses may do
additional asynchronous actions before even handing a command down to
it.

Currently, there's no way for subclasses to postpone actions if a
command is already in progress.

This commit exposes `isCommandInProgress()`, which subclasses can use to
postpone (by stashing) incoming messages when an actual command is
already behind handled.

The commit also adds a missing log message when the first actual command
isn't actually handled by the subclass' implementation of
`createReceive()`, and removes a FIXME that has since been implemented.