### PR TITLE
Keep metrics on number of workers, and number of actual streams

### DIFF
--- a/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerMetrics.java
+++ b/ts-reaktive-actors/src/main/java/com/tradeshift/reaktive/materialize/MaterializerMetrics.java
@@ -23,6 +23,8 @@ public class MaterializerMetrics {
     private final GaugeMetric remaining;
     /** The duration, milliseconds, of materializing a single event */
     private final HistogramMetric materializationDuration;
+    private final Gauge workers;
+    private final Gauge streams;
 
     public MaterializerMetrics(String name, Map<String, String> additionalTags) {
         baseTags = additionalTags.put("journal-materializer", name);
@@ -34,8 +36,9 @@ public class MaterializerMetrics {
         this.delay = Kamon.gauge("journal-materializer.delay", MeasurementUnit.time().milliseconds());
         this.remaining = Kamon.gauge("journal-materializer.remaining", MeasurementUnit.time().milliseconds());
         this.materializationDuration = Kamon.histogram("journal-materializer.materialization-duration", MeasurementUnit.time().milliseconds());
+        this.workers = Kamon.gauge("journal-materializer.workers").refine(tags);
+        this.streams = Kamon.gauge("journal-materializer.streams").refine(tags);
     }
-
 
     public Counter getEvents(int index) {
         return events.refine(baseTags.put("index", String.valueOf(index)).toJavaMap());
@@ -63,5 +66,13 @@ public class MaterializerMetrics {
 
     public Gauge getReimportRemaining() {
         return reimportRemaining;
+    }
+
+    public Gauge getWorkers() {
+        return workers;
+    }
+
+    public Gauge getStreams() {
+        return streams;
     }
 }


### PR DESCRIPTION
Some monitoring systems could be repeating the last-known metric for a
stopped worker. By sending actual metrics on the number of workers (and
the number of actual streams), we will be able to better follow what's
really going on.